### PR TITLE
New improved NoInput/NoPresenter handling, cleaner `perform` impls

### DIFF
--- a/FlintCore/Actions/ActionContext.swift
+++ b/FlintCore/Actions/ActionContext.swift
@@ -21,7 +21,7 @@ public class ActionContext<InputType> where InputType: CustomStringConvertible {
     }
     
     /// The input to the action
-    public let input: InputType?
+    public let input: InputType
 
     /// The contextual logs for the action
     public let logs: Logs = .init()
@@ -31,7 +31,7 @@ public class ActionContext<InputType> where InputType: CustomStringConvertible {
     
     private let session: ActionSession
     
-    init(input: InputType?, session: ActionSession, source: ActionSource) {
+    init(input: InputType, session: ActionSession, source: ActionSource) {
         self.input = input
         self.session = session
         self.source = source
@@ -58,14 +58,10 @@ public class ActionContext<InputType> where InputType: CustomStringConvertible {
     }
 
     public var debugDescriptionOfInput: String? {
-        if let input = input {
-            if input is NoInput {
-                return nil
-            } else {
-                return String(reflecting: input)
-            }
-        } else {
+        if input is NoInput {
             return nil
+        } else {
+            return String(reflecting: input)
         }
     }
 }

--- a/FlintCore/Actions/ActionRequest.swift
+++ b/FlintCore/Actions/ActionRequest.swift
@@ -27,7 +27,7 @@ public class ActionRequest<FeatureType: FeatureDefinition, ActionType: Action>: 
     /// The initialiser is internal access only to prevent creation of requests outside of this framework, which could short
     /// circuit some of the safety checks around availabilty of features
     init(uniqueID: UInt, userInitiated: Bool, source: ActionSource, session: ActionSession, actionBinding: StaticActionBinding<FeatureType, ActionType>,
-         input: ActionType.InputType?, presenter: ActionType.PresenterType,
+         input: ActionType.InputType, presenter: ActionType.PresenterType,
          logContextCreator: @escaping ((_ sessionID: String, _ activitySequenceID: String) -> LogEventContext)) {
         date = Date()
         self.uniqueID = uniqueID

--- a/FlintCore/Actions/NoPresenter.swift
+++ b/FlintCore/Actions/NoPresenter.swift
@@ -10,4 +10,4 @@ import Foundation
 
 /// Convenience type for use when no presenter type is requred.
 /// - see: `Action`
-public typealias NoPresenter = Void? 
+public typealias NoPresenter = Void

--- a/FlintCore/Actions/StaticActionBinding.swift
+++ b/FlintCore/Actions/StaticActionBinding.swift
@@ -86,3 +86,44 @@ public struct StaticActionBinding<FeatureType, ActionType>: CustomDebugStringCon
         ActionSession.main.perform(self, using: presenter, with: input, userInitiated: userInitiated, source: source, completion: completion)
     }
 }
+
+extension StaticActionBinding where ActionType.PresenterType == NoPresenter {
+    public func perform(with input: ActionType.InputType,
+                        completion: ((ActionOutcome) -> ())? = nil) {
+        ActionSession.main.perform(self, using: NoPresenter(), with: input, completion: completion)
+    }
+
+    public func perform(with input: ActionType.InputType,
+                        userInitiated: Bool,
+                        source: ActionSource,
+                        completion: ((ActionOutcome) -> ())? = nil) {
+        ActionSession.main.perform(self, using: NoPresenter(), with: input, userInitiated: userInitiated, source: source, completion: completion)
+    }
+}
+
+extension StaticActionBinding where ActionType.InputType == NoInput {
+    public func perform(using presenter: ActionType.PresenterType,
+                        completion: ((ActionOutcome) -> ())? = nil) {
+        ActionSession.main.perform(self, using: presenter, with: NoInput.none, completion: completion)
+    }
+
+    public func perform(using presenter: ActionType.PresenterType,
+                        userInitiated: Bool,
+                        source: ActionSource,
+                        completion: ((ActionOutcome) -> ())? = nil) {
+        ActionSession.main.perform(self, using: presenter, with: NoInput.none, userInitiated: userInitiated, source: source, completion: completion)
+    }
+}
+
+
+extension StaticActionBinding where ActionType.InputType == NoInput, ActionType.PresenterType == NoPresenter {
+    public func perform(completion: ((ActionOutcome) -> ())? = nil) {
+        ActionSession.main.perform(self, using: NoPresenter(), with: NoInput.none, completion: completion)
+    }
+
+    public func perform(userInitiated: Bool,
+                        source: ActionSource,
+                        completion: ((ActionOutcome) -> ())? = nil) {
+        ActionSession.main.perform(self, using: NoPresenter(), with: NoInput.none, userInitiated: userInitiated, source: source, completion: completion)
+    }
+}

--- a/FlintCore/Activities/ActivityActionDispatchObserver.swift
+++ b/FlintCore/Activities/ActivityActionDispatchObserver.swift
@@ -64,7 +64,7 @@ public class ActivityActionDispatchObserver: ActionDispatchObserver {
                                                 activityTypes: activityTypes,
                                                 appLink: appLink)
         DispatchQueue.main.async {
-            publishRequest.perform(using: nil, with: publishState, userInitiated: false, source: .application)
+            publishRequest.perform(using: NoPresenter(), with: publishState, userInitiated: false, source: .application)
         }
     }
 }

--- a/FlintCore/Activities/HandleActivityAction.swift
+++ b/FlintCore/Activities/HandleActivityAction.swift
@@ -17,13 +17,9 @@ final class HandleActivityAction: Action {
     static let description: String = "Automatic action dispatch for incoming NSUserActivity instances published by Flint"
     
     static func perform(with context: ActionContext<NSUserActivity>, using presenter: PresentationRouter, completion: @escaping (ActionPerformOutcome) -> Void) {
-        guard let state = context.input else {
-            return completion(.failure(error: nil, closeActionStack: true))
-        }
-        
         // Do we need to check if activityType == CSSearchableItemActionType for spotlight invocations?
         
-        if let autoURL = state.userInfo?[ActivitiesFeature.autoURLUserInfoKey] as? URL {
+        if let autoURL = context.input.userInfo?[ActivitiesFeature.autoURLUserInfoKey] as? URL {
             context.logs.development?.debug("Auto URL found: \(autoURL)")
             if let request = RoutesFeature.request(RoutesFeature.performIncomingURL) {
                 request.perform(using: presenter, with: autoURL, userInitiated: true, source: context.source) { outcome in
@@ -35,7 +31,7 @@ final class HandleActivityAction: Action {
                 return completion(.failure(error: nil, closeActionStack: true))
             }
         } else {
-            context.logs.development?.debug("Auto Activity handling did not find url in Activity: \(state)")
+            context.logs.development?.debug("Auto Activity handling did not find url in Activity: \(context.input)")
             return completion(.failure(error: nil, closeActionStack: true))
         }
     }

--- a/FlintCore/Activities/PublishCurrentActionActivityAction.swift
+++ b/FlintCore/Activities/PublishCurrentActionActivityAction.swift
@@ -26,18 +26,14 @@ final class PublishCurrentActionActivityAction: Action {
     static let bundleID = Bundle.main.bundleIdentifier!
 
     static func perform(with context: ActionContext<InputType>, using presenter: NoPresenter, completion: @escaping (ActionPerformOutcome) -> Void) {
-        guard let input = context.input else {
-            preconditionFailure("Expected a state of type \(InputType.self)")
-        }
-
-        let activityTypes = input.activityTypes
+        let activityTypes = context.input.activityTypes
         guard activityTypes.count > 0 else {
             return completion(.success(closeActionStack: true))
         }
         
         // These are the basic activity requirements
         /// !!! TODO: This should use the identifier, not the name. The name may change or be non-unique
-        let activityID = "\(bundleID).\(input.actionName.lowerCasedID())"
+        let activityID = "\(bundleID).\(context.input.actionName.lowerCasedID())"
         precondition(FlintAppInfo.activityTypes.contains(activityID),
                      "The Info.plist property NSUserActivityTypes must include all activity type IDs you support. " +
                      "The ID `\(activityID)` is not there.")
@@ -50,7 +46,7 @@ final class PublishCurrentActionActivityAction: Action {
 
         // If the action provides some extra data, use this. Note that the prepareFunction has already been
         // essentially "curried" to capture the original `input` of the action being published.
-        guard let preparedActivity = input.prepareFunction(activity) else {
+        guard let preparedActivity = context.input.prepareFunction(activity) else {
             return completion(.success(closeActionStack: true))
         }
         
@@ -60,7 +56,7 @@ final class PublishCurrentActionActivityAction: Action {
             }
         }
         
-        if let url = input.appLink {
+        if let url = context.input.appLink {
             activity.addUserInfoEntries(from: [ActivitiesFeature.autoURLUserInfoKey: url])
         }
         

--- a/FlintCore/Conditional Features/ConditionalActionRequest.swift
+++ b/FlintCore/Conditional Features/ConditionalActionRequest.swift
@@ -36,5 +36,44 @@ public struct ConditionalActionRequest<FeatureType, ActionType> where FeatureTyp
                        completion: ((ActionOutcome) -> ())? = nil) {
         ActionSession.main.perform(self, using: presenter, with: input, userInitiated: userInitiated, source: source, completion: completion)
     }
+}
 
+extension ConditionalActionRequest where ActionType.PresenterType == NoPresenter {
+    public func perform(with input: ActionType.InputType,
+                        completion: ((ActionOutcome) -> ())? = nil) {
+        ActionSession.main.perform(self, using: NoPresenter(), with: input, completion: completion)
+    }
+
+    public func perform(with input: ActionType.InputType,
+                        userInitiated: Bool,
+                        source: ActionSource,
+                        completion: ((ActionOutcome) -> ())? = nil) {
+        ActionSession.main.perform(self, using: NoPresenter(), with: input, userInitiated: userInitiated, source: source, completion: completion)
+    }
+}
+
+extension ConditionalActionRequest where ActionType.InputType == NoInput {
+    public func perform(using presenter: ActionType.PresenterType,
+                        completion: ((ActionOutcome) -> ())? = nil) {
+        ActionSession.main.perform(self, using: presenter, with: NoInput.none, completion: completion)
+    }
+
+    public func perform(using presenter: ActionType.PresenterType,
+                        userInitiated: Bool,
+                        source: ActionSource,
+                        completion: ((ActionOutcome) -> ())? = nil) {
+        ActionSession.main.perform(self, using: presenter, with: NoInput.none, userInitiated: userInitiated, source: source, completion: completion)
+    }
+}
+
+extension ConditionalActionRequest where ActionType.InputType == NoInput, ActionType.PresenterType == NoPresenter {
+    public func perform(completion: ((ActionOutcome) -> ())? = nil) {
+        ActionSession.main.perform(self, using: NoPresenter(), with: NoInput.none, completion: completion)
+    }
+
+    public func perform(userInitiated: Bool,
+                        source: ActionSource,
+                        completion: ((ActionOutcome) -> ())? = nil) {
+        ActionSession.main.perform(self, using: NoPresenter(), with: NoInput.none, userInitiated: userInitiated, source: source, completion: completion)
+    }
 }

--- a/FlintCore/Core/ActionSession.swift
+++ b/FlintCore/Core/ActionSession.swift
@@ -91,15 +91,15 @@ public class ActionSession: CustomDebugStringConvertible {
     ///
     /// This is how you execute actions that are not always available.
     ///
-    /// The completion handler is called on main queue because the action is performed in the main `ActionSession`
+    /// The completion handler is called on `callerQueue` of this `ActionSession`
     ///
     /// - param presenter: The object presenting the outcome of the action
     /// - param input: The value to pass as the input of the action
     /// - param completion: The completion handler to call.
     public func perform<FeatureType, ActionType>(_ conditionalRequest: ConditionalActionRequest<FeatureType, ActionType>,
-                           using presenter: ActionType.PresenterType,
-                           with input: ActionType.InputType,
-                           completion: ((ActionOutcome) -> ())? = nil) {
+                                                 using presenter: ActionType.PresenterType,
+                                                 with input: ActionType.InputType,
+                                                 completion: ((ActionOutcome) -> ())? = nil) {
         perform(conditionalRequest, using: presenter, with: input, userInitiated: userInitiatedActions, source: .application, completion: completion)
     }
     
@@ -107,7 +107,54 @@ public class ActionSession: CustomDebugStringConvertible {
     ///
     /// This is how you execute actions that are not always available.
     ///
-    /// The completion handler is called on main queue because the action is performed in the main `ActionSession`
+    /// The completion handler is called on `callerQueue` of this `ActionSession`
+    ///
+    /// - param presenter: The object presenting the outcome of the action
+    /// - param input: The value to pass as the input of the action
+    /// - param completion: The completion handler to call.
+    public func perform<FeatureType, ActionType>(_ conditionalRequest: ConditionalActionRequest<FeatureType, ActionType>,
+                                                 with input: ActionType.InputType,
+                                                 completion: ((ActionOutcome) -> ())? = nil)
+                                                 where ActionType.PresenterType == NoPresenter {
+        perform(conditionalRequest, using: NoPresenter(), with: input, userInitiated: userInitiatedActions, source: .application, completion: completion)
+    }
+
+    /// Perform the action associated with a conditional request obtained from `ConditionalFeature.request`.
+    ///
+    /// This is how you execute actions that are not always available.
+    ///
+    /// The completion handler is called on `callerQueue` of this `ActionSession`
+    ///
+    /// - param presenter: The object presenting the outcome of the action
+    /// - param input: The value to pass as the input of the action
+    /// - param completion: The completion handler to call.
+    public func perform<FeatureType, ActionType>(_ conditionalRequest: ConditionalActionRequest<FeatureType, ActionType>,
+                                                 using presenter: ActionType.PresenterType,
+                                                 completion: ((ActionOutcome) -> ())? = nil)
+                                                 where ActionType.InputType == NoInput {
+        perform(conditionalRequest, using: presenter, with: .none, userInitiated: userInitiatedActions, source: .application, completion: completion)
+    }
+
+    /// Perform the action associated with a conditional request obtained from `ConditionalFeature.request`.
+    ///
+    /// This is how you execute actions that are not always available.
+    ///
+    /// The completion handler is called on `callerQueue` of this `ActionSession`
+    ///
+    /// - param presenter: The object presenting the outcome of the action
+    /// - param input: The value to pass as the input of the action
+    /// - param completion: The completion handler to call.
+    public func perform<FeatureType, ActionType>(_ conditionalRequest: ConditionalActionRequest<FeatureType, ActionType>,
+                                                 completion: ((ActionOutcome) -> ())? = nil)
+                                                 where ActionType.InputType == NoInput, ActionType.PresenterType == NoPresenter {
+        perform(conditionalRequest, using: NoPresenter(), with: .none, userInitiated: userInitiatedActions, source: .application, completion: completion)
+    }
+
+    /// Perform the action associated with a conditional request obtained from `ConditionalFeature.request`.
+    ///
+    /// This is how you execute actions that are not always available.
+    ///
+    /// The completion handler is called on `callerQueue` of this `ActionSession`
     ///
     /// - param presenter: The object presenting the outcome of the action
     /// - param input: The value to pass as the input of the action
@@ -128,14 +175,14 @@ public class ActionSession: CustomDebugStringConvertible {
                                    arguments: input.description,
                                    presenter: String(describing: presenter))
         }
-        let actionRequest: ActionRequest<FeatureType, ActionType> = ActionRequest(uniqueID: nextRequestID(),
-                                                            userInitiated: userInitiated,
-                                                            source: source,
-                                                            session: self,
-                                                            actionBinding: staticBinding,
-                                                            input: input,
-                                                            presenter: presenter,
-                                                            logContextCreator: logContextCreator)
+        let actionRequest = ActionRequest(uniqueID: nextRequestID(),
+                                          userInitiated: userInitiated,
+                                          source: source,
+                                          session: self,
+                                          actionBinding: staticBinding,
+                                          input: input,
+                                          presenter: presenter,
+                                          logContextCreator: logContextCreator)
         perform(actionRequest, completion: completion)
     }
     
@@ -144,23 +191,72 @@ public class ActionSession: CustomDebugStringConvertible {
     ///
     /// This is how you execute actions that are always available.
     ///
-    /// The completion handler is called on main queue because the action is performed in the main `ActionSession`
+    /// The completion handler is called on `callerQueue` of this `ActionSession`
     ///
     /// - param presenter: The object presenting the outcome of the action
     /// - param input: The value to pass as the input of the action
     /// - param completion: The completion handler to call.
     public func perform<FeatureType, ActionType>(_ actionBinding: StaticActionBinding<FeatureType, ActionType>,
-                           using presenter: ActionType.PresenterType,
-                           with input: ActionType.InputType,
-                           completion: ((ActionOutcome) -> ())? = nil) {
-        perform(actionBinding, using: presenter, with: input, userInitiated: userInitiatedActions, source: .application, completion: completion)
+                                                 using presenter: ActionType.PresenterType,
+                                                 with input: ActionType.InputType,
+                                                 completion: ((ActionOutcome) -> ())? = nil) {
+        perform(actionBinding, using: presenter, with: input, userInitiated: userInitiatedActions,
+                source: .application, completion: completion)
     }
     
     /// Perform an action associated with an unconditional `Feature`.
     ///
+    /// This is how you execute actions that are always available, when they have no presenter (`NoPresenter`) requirement.
+    ///
+    /// The completion handler is called on `callerQueue` of this `ActionSession`
+    ///
+    /// - param input: The value to pass as the input of the action
+    /// - param completion: The completion handler to call.
+    public func perform<FeatureType, ActionType>(_ actionBinding: StaticActionBinding<FeatureType, ActionType>,
+                                                 with input: ActionType.InputType,
+                                                 completion: ((ActionOutcome) -> ())? = nil)
+                                                 where ActionType.PresenterType == NoPresenter {
+        perform(actionBinding, using: NoPresenter(), with: input, userInitiated: userInitiatedActions,
+                source: .application, completion: completion)
+    }
+
+    /// Perform an action associated with an unconditional `Feature`.
+    ///
+    /// This is how you execute actions that are always available, when they have no input (`NoInput`) requirement.
+    ///
+    /// The completion handler is called on `callerQueue` of this `ActionSession`
+    ///
+    /// - param input: The value to pass as the input of the action
+    /// - param completion: The completion handler to call.
+    public func perform<FeatureType, ActionType>(_ actionBinding: StaticActionBinding<FeatureType, ActionType>,
+                                                 using presenter: ActionType.PresenterType,
+                                                 completion: ((ActionOutcome) -> ())? = nil)
+                                                 where ActionType.InputType == NoInput {
+        perform(actionBinding, using: presenter, with: .none, userInitiated: userInitiatedActions,
+                source: .application, completion: completion)
+    }
+
+    /// Perform an action associated with an unconditional `Feature`.
+    ///
+    /// This is how you execute actions that are always available, when they have no input (`NoInput`) requirement and
+    /// no presenter (`NoPresenter`) requirement.
+    ///
+    /// The completion handler is called on `callerQueue` of this `ActionSession`
+    ///
+    /// - param input: The value to pass as the input of the action
+    /// - param completion: The completion handler to call.
+    public func perform<FeatureType, ActionType>(_ actionBinding: StaticActionBinding<FeatureType, ActionType>,
+                                                 completion: ((ActionOutcome) -> ())? = nil)
+                                                 where ActionType.InputType == NoInput, ActionType.PresenterType == NoPresenter {
+        perform(actionBinding, using: NoPresenter(), with: .none, userInitiated: userInitiatedActions,
+                source: .application, completion: completion)
+    }
+
+    /// Perform an action associated with an unconditional `Feature`.
+    ///
     /// This is how you execute actions that are always available.
     ///
-    /// The completion handler is called on main queue because the action is performed in the main `ActionSession`
+    /// The completion handler is called on `callerQueue` of this `ActionSession`
     ///
     /// - param presenter: The object presenting the outcome of the action
     /// - param input: The value to pass as the input of the action
@@ -251,5 +347,4 @@ public class ActionSession: CustomDebugStringConvertible {
             }
         })
     }
-    
 }

--- a/FlintCore/Core/ActionStackEntry.swift
+++ b/FlintCore/Core/ActionStackEntry.swift
@@ -44,7 +44,7 @@ public struct ActionStackEntry: CustomDebugStringConvertible {
         feature = request.actionBinding.feature
         details = .action(name: request.actionBinding.action.name,
                           source: request.source,
-                          input: request.context.input == nil ? nil : String(reflecting: request.context.input))
+                          input: String(reflecting: request.context.input))
         self.sessionName = sessionName
         // Do this so that we don't retain the request.
         debugDescription = request.debugDescription

--- a/FlintCore/Focus/FocusFeature.swift
+++ b/FlintCore/Focus/FocusFeature.swift
@@ -83,11 +83,7 @@ final public class FocusAction: Action {
     public typealias PresenterType = NoPresenter
 
     public static func perform(with context: ActionContext<InputType>, using presenter: PresenterType, completion: @escaping (ActionPerformOutcome) -> Void) {
-        guard let input = context.input else {
-            preconditionFailure("Input is required")
-        }
-
-        FocusFeature.dependencies.focusSelection?.focus(input.topicPath)
+        FocusFeature.dependencies.focusSelection?.focus(context.input.topicPath)
         
         completion(.success(closeActionStack: true))
     }
@@ -98,11 +94,7 @@ final public class DefocusAction: Action {
     public typealias PresenterType = NoPresenter
 
     public static func perform(with context: ActionContext<InputType>, using presenter: PresenterType, completion: @escaping (ActionPerformOutcome) -> Void) {
-        guard let input = context.input else {
-            preconditionFailure("Input is required")
-        }
-
-        FocusFeature.dependencies.focusSelection?.defocus(input.topicPath)
+        FocusFeature.dependencies.focusSelection?.defocus(context.input.topicPath)
 
         completion(.success(closeActionStack: true))
     }

--- a/FlintCore/Routes/PerformIncomingURLAction.swift
+++ b/FlintCore/Routes/PerformIncomingURLAction.swift
@@ -37,11 +37,7 @@ final public class PerformIncomingURLAction: Action {
     /// The completion outcome will fail with error `noURLMappingFound` if the URL does not map to anything
     /// that Flint knows about.
     public static func perform(with context: ActionContext<URL>, using presenter: PresentationRouter, completion: @escaping (ActionPerformOutcome) -> Void) {
-        guard let url = context.input else {
-            context.logs.development?.error("No URL supplied")
-            return completion(.failure(error: nil, closeActionStack: false))
-        }
-        guard let urlComponents = URLComponents(url: url, resolvingAgainstBaseURL: false) else {
+        guard let urlComponents = URLComponents(url: context.input, resolvingAgainstBaseURL: false) else {
             context.logs.development?.error("Invalid URL supplied")
             return completion(.failure(error: nil, closeActionStack: false))
         }
@@ -76,7 +72,7 @@ final public class PerformIncomingURLAction: Action {
         }
 
         guard let foundScope = scope, let foundPath = path else {
-            context.logs.development?.error("Couldn't map URL: \(url)")
+            context.logs.development?.error("Couldn't map URL: \(context.input)")
             return completion(.failure(error: URLActionError.noURLMappingFound, closeActionStack: true))
         }
 
@@ -94,7 +90,7 @@ final public class PerformIncomingURLAction: Action {
                 return completion(outcome)
             }
         } else {
-            context.logs.development?.error("Couldn't get executor for URL: \(url) for scope \(foundScope) and path \(foundPath)")
+            context.logs.development?.error("Couldn't get executor for URL: \(context.input) for scope \(foundScope) and path \(foundPath)")
             return completion(.failure(error: URLActionError.noURLMappingFound, closeActionStack: true))
         }
         

--- a/FlintCore/Timeline/Timeline.swift
+++ b/FlintCore/Timeline/Timeline.swift
@@ -50,8 +50,8 @@ public class Timeline: ActionDispatchObserver, DebugReportable {
                                   sessionName: request.sessionName,
                                   feature: request.actionBinding.feature,
                                   actionName: request.actionBinding.action.name,
-                                  inputDescription: request.context.input?.description,
-                                  inputDebugDescription: request.context.input == nil ? nil : String(reflecting: request.context.input))
+                                  inputDescription: request.context.input.description,
+                                  inputDebugDescription: String(reflecting: request.context.input))
         entries.append(entry)
     }
     
@@ -69,8 +69,8 @@ public class Timeline: ActionDispatchObserver, DebugReportable {
                                   sessionName: request.sessionName,
                                   feature: request.actionBinding.feature,
                                   actionName: request.actionBinding.action.name,
-                                  inputDescription: request.context.input?.description,
-                                  inputDebugDescription: request.context.input == nil ? nil : String(reflecting: request.context.input),
+                                  inputDescription: request.context.input.description,
+                                  inputDebugDescription: String(reflecting: request.context.input),
                                   outcome: outcome.simplifiedOutcome)
         entries.append(entry)
     }

--- a/FlintCoreTests/DebugReportingTests.swift
+++ b/FlintCoreTests/DebugReportingTests.swift
@@ -27,7 +27,7 @@ class DebugReportingTests: XCTestCase {
 
     func testGatheringZipReport() {
         Flint.quickSetup(DummyFeatures.self)
-        DummyStaticFeature.action1.perform(using: nil, with: .none)
+        DummyStaticFeature.action1.perform()
         let zipUrl = DebugReporting.gatherReportZip()
         XCTAssert(FileManager.default.fileExists(atPath: zipUrl.path))
     }

--- a/FlintUI/Features/FocusLogDataAccessFeature.swift
+++ b/FlintUI/Features/FocusLogDataAccessFeature.swift
@@ -36,8 +36,6 @@ final public class FocusLogDataAccessFeature: ConditionalFeature {
         public static var description: String = "Loads the initial results from the Focus Log"
 
         public static var hideFromTimeline: Bool = true
-
-        public static let defaultInitialItemCount = 5
         
         public static func perform(with context: ActionContext<InputType>, using presenter: PresenterType, completion: @escaping (ActionPerformOutcome) -> Void) {
             guard let logs = FocusFeature.dependencies.developmentFocusLogging else {
@@ -47,7 +45,7 @@ final public class FocusLogDataAccessFeature: ConditionalFeature {
 
             let focusLogController = TimeOrderedResultsController(dataSource: logs.history, delegate: presenter, delegateQueue: .main)
             presenter.focusLogController = focusLogController
-            focusLogController.loadMore(count: context.input ?? defaultInitialItemCount)
+            focusLogController.loadMore(count: context.input)
 
             completion(.success(closeActionStack: false))
         }
@@ -67,7 +65,7 @@ final public class FocusLogDataAccessFeature: ConditionalFeature {
             guard let focusLogController = presenter.focusLogController else {
                 preconditionFailure("Initial results have not been loaded")
             }
-            focusLogController.loadMore(count: context.input ?? defaultExtraPageCount)
+            focusLogController.loadMore(count: context.input)
             completion(.success(closeActionStack: false))
         }
     }

--- a/FlintUI/Features/TimelineDataAccessFeature.swift
+++ b/FlintUI/Features/TimelineDataAccessFeature.swift
@@ -37,13 +37,11 @@ final public class TimelineDataAccessFeature: ConditionalFeature {
 
         public static var hideFromTimeline: Bool = true
 
-        public static let defaultInitialItemCount = 5
-        
         public static func perform(with context: ActionContext<InputType>, using presenter: PresenterType, completion: @escaping (ActionPerformOutcome) -> Void) {
             let timeline = Timeline.instance
             let timelineController = TimeOrderedResultsController(dataSource: timeline.entries, delegate: presenter, delegateQueue: .main)
             presenter.timelineController = timelineController
-            timelineController.loadMore(count: context.input ?? defaultInitialItemCount)
+            timelineController.loadMore(count: context.input)
             completion(.success(closeActionStack: false))
         }
     }
@@ -62,7 +60,7 @@ final public class TimelineDataAccessFeature: ConditionalFeature {
             guard let timelineController = presenter.timelineController else {
                 preconditionFailure("Initial results have not been loaded")
             }
-            timelineController.loadMore(count: context.input ?? defaultExtraPageCount)
+            timelineController.loadMore(count: context.input)
             completion(.success(closeActionStack: false))
         }
     }

--- a/FlintUISandbox/AppDelegate.swift
+++ b/FlintUISandbox/AppDelegate.swift
@@ -69,14 +69,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         testTimer?.schedule(deadline: DispatchTime.now(), repeating: 10.0)
         testTimer?.setEventHandler(handler: {
             print("Performing a fake feature, this will show even if not in Focus")
-            FakeFeature.action1.perform(using: nil, with: .none)
+            FakeFeature.action1.perform(with: .none)
             logger?.debug("Test output from logger")
         })
         testTimer?.resume()
         
         DispatchQueue.main.asyncAfter(deadline: .now() + 20) {
             if let request = FocusFeature.request(FocusFeature.resetFocus) {
-                request.perform(using: nil, with: .none)
+                request.perform(with: .none)
             }
         }
         return true

--- a/FlintUISandbox/ViewController.swift
+++ b/FlintUISandbox/ViewController.swift
@@ -17,7 +17,7 @@ class ViewController: UITableViewController {
 
         // Trigger some fake data
 
-        FakeFeature.action1.perform(using: nil, with: .none, completion: { (outcome: ActionOutcome) in
+        FakeFeature.action1.perform(with: .none, completion: { (outcome: ActionOutcome) in
             switch outcome {
                 case .success:
                    assert(true)
@@ -25,7 +25,7 @@ class ViewController: UITableViewController {
                    assert(false)
             }
         })
-        FakeFeature.action1.perform(using: nil, with: .none, userInitiated: false, source: .application, completion: { (outcome: ActionOutcome) in
+        FakeFeature.action1.perform(with: .none, userInitiated: false, source: .application, completion: { (outcome: ActionOutcome) in
             switch outcome {
                 case .success:
                    assert(true)
@@ -50,13 +50,13 @@ class ViewController: UITableViewController {
                 guard let request = TimelineBrowserFeature.request(TimelineBrowserFeature.show) else {
                     preconditionFailure("Timeline is not enabled")
                 }
-                request.perform(using: navigationController, with: .none)
+                request.perform(using: navigationController)
             case 2: ActionStackBrowserFeature.show.perform(using: navigationController, with: .none)
             case 3:
                 guard let request = LogBrowserFeature.request(LogBrowserFeature.show) else {
                     preconditionFailure("Timeline is not enabled")
                 }
-                request.perform(using: navigationController, with: .none)
+                request.perform(using: navigationController)
             default: preconditionFailure()
         }
         


### PR DESCRIPTION
This greatly improves the ergonomics of performing actions that either need no input, no presenter or need neither.

It also means actions no longer need to test for possibly nil input, because we couldn't specify optional associated types due to Swift limitations.

Fixes #49 