### PR TITLE
Rework availability checking and purchase checking APIs

### DIFF
--- a/FlintCore.xcodeproj/project.pbxproj
+++ b/FlintCore.xcodeproj/project.pbxproj
@@ -84,7 +84,7 @@
 		495FD9FC20026A520007A427 /* ObserverSet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495FD9FB20026A520007A427 /* ObserverSet.swift */; };
 		495FD9FE200363290007A427 /* FeaturePath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495FD9FD200363290007A427 /* FeaturePath.swift */; };
 		496267B41F8BC14D002C83F2 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 496267B31F8BC14D002C83F2 /* README.md */; };
-		49647D372037434B005F9825 /* StoreKitPurchaseValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49647D362037434B005F9825 /* StoreKitPurchaseValidator.swift */; };
+		49647D372037434B005F9825 /* StoreKitPurchaseTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49647D362037434B005F9825 /* StoreKitPurchaseTracker.swift */; };
 		49647D3920374DE1005F9825 /* ActionStackEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49647D3820374DE1005F9825 /* ActionStackEntry.swift */; };
 		49647D3B20384077005F9825 /* ActivitiesFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49647D3A20384077005F9825 /* ActivitiesFeature.swift */; };
 		49647D3D203873C7005F9825 /* FlintFeatures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49647D3C203873C7005F9825 /* FlintFeatures.swift */; };
@@ -160,25 +160,25 @@
 		496F8F82203EEBBA003AB29B /* ConditionalActionBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F2CF231FF7EB2C004F16EF /* ConditionalActionBinding.swift */; };
 		496F8F83203EEBBA003AB29B /* AvailabilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49966D8E200A63D1004C4AA0 /* AvailabilityChecker.swift */; };
 		496F8F84203EEBBA003AB29B /* UserFeatureToggles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49966D90200A63EB004C4AA0 /* UserFeatureToggles.swift */; };
-		496F8F85203EEBBA003AB29B /* PurchaseValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49966D92200A644A004C4AA0 /* PurchaseValidator.swift */; };
+		496F8F85203EEBBA003AB29B /* PurchaseTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49966D92200A644A004C4AA0 /* PurchaseTracker.swift */; };
 		496F8F86203EEBBA003AB29B /* UserDefaultsFeatureToggles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49966D94200A6472004C4AA0 /* UserDefaultsFeatureToggles.swift */; };
 		496F8F87203EEBBA003AB29B /* DefaultAvailabilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49966D96200A648A004C4AA0 /* DefaultAvailabilityChecker.swift */; };
-		496F8F88203EEBBA003AB29B /* StoreKitPurchaseValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49647D362037434B005F9825 /* StoreKitPurchaseValidator.swift */; };
+		496F8F88203EEBBA003AB29B /* StoreKitPurchaseTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49647D362037434B005F9825 /* StoreKitPurchaseTracker.swift */; };
 		496F8F89203EEBBB003AB29B /* ConditionalFeatureDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49819EBF1FC9C6D90013AF55 /* ConditionalFeatureDefinition.swift */; };
 		496F8F8A203EEBBB003AB29B /* ConditionalFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D447F61FEC6AA800DBB352 /* ConditionalFeature.swift */; };
 		496F8F8B203EEBBB003AB29B /* ConditionalActionBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F2CF231FF7EB2C004F16EF /* ConditionalActionBinding.swift */; };
 		496F8F8C203EEBBB003AB29B /* AvailabilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49966D8E200A63D1004C4AA0 /* AvailabilityChecker.swift */; };
 		496F8F8D203EEBBB003AB29B /* UserFeatureToggles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49966D90200A63EB004C4AA0 /* UserFeatureToggles.swift */; };
-		496F8F8E203EEBBB003AB29B /* PurchaseValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49966D92200A644A004C4AA0 /* PurchaseValidator.swift */; };
+		496F8F8E203EEBBB003AB29B /* PurchaseTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49966D92200A644A004C4AA0 /* PurchaseTracker.swift */; };
 		496F8F8F203EEBBB003AB29B /* UserDefaultsFeatureToggles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49966D94200A6472004C4AA0 /* UserDefaultsFeatureToggles.swift */; };
 		496F8F90203EEBBB003AB29B /* DefaultAvailabilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49966D96200A648A004C4AA0 /* DefaultAvailabilityChecker.swift */; };
-		496F8F91203EEBBB003AB29B /* StoreKitPurchaseValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49647D362037434B005F9825 /* StoreKitPurchaseValidator.swift */; };
+		496F8F91203EEBBB003AB29B /* StoreKitPurchaseTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49647D362037434B005F9825 /* StoreKitPurchaseTracker.swift */; };
 		496F8F92203EEBBC003AB29B /* ConditionalFeatureDefinition.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49819EBF1FC9C6D90013AF55 /* ConditionalFeatureDefinition.swift */; };
 		496F8F93203EEBBC003AB29B /* ConditionalFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D447F61FEC6AA800DBB352 /* ConditionalFeature.swift */; };
 		496F8F94203EEBBC003AB29B /* ConditionalActionBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F2CF231FF7EB2C004F16EF /* ConditionalActionBinding.swift */; };
 		496F8F95203EEBBC003AB29B /* AvailabilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49966D8E200A63D1004C4AA0 /* AvailabilityChecker.swift */; };
 		496F8F96203EEBBC003AB29B /* UserFeatureToggles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49966D90200A63EB004C4AA0 /* UserFeatureToggles.swift */; };
-		496F8F97203EEBBC003AB29B /* PurchaseValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49966D92200A644A004C4AA0 /* PurchaseValidator.swift */; };
+		496F8F97203EEBBC003AB29B /* PurchaseTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49966D92200A644A004C4AA0 /* PurchaseTracker.swift */; };
 		496F8F98203EEBBC003AB29B /* UserDefaultsFeatureToggles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49966D94200A6472004C4AA0 /* UserDefaultsFeatureToggles.swift */; };
 		496F8F99203EEBBC003AB29B /* DefaultAvailabilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49966D96200A648A004C4AA0 /* DefaultAvailabilityChecker.swift */; };
 		496F8F9B203EEBC4003AB29B /* RoutesFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 498AF6E42028972A00AFE666 /* RoutesFeature.swift */; };
@@ -295,6 +295,9 @@
 		49839CED2046D1D500C0AED3 /* DebugReporting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49839CEC2046D1D500C0AED3 /* DebugReporting.swift */; };
 		49839CEE2046D1D500C0AED3 /* DebugReporting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49839CEC2046D1D500C0AED3 /* DebugReporting.swift */; };
 		49839CEF2046D1D500C0AED3 /* DebugReporting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49839CEC2046D1D500C0AED3 /* DebugReporting.swift */; };
+		49891EB22094BEB600B9BCBF /* PurchaseTrackerObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49891EB12094BEB600B9BCBF /* PurchaseTrackerObserver.swift */; };
+		49891EB32094BEB600B9BCBF /* PurchaseTrackerObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49891EB12094BEB600B9BCBF /* PurchaseTrackerObserver.swift */; };
+		49891EB42094BEB600B9BCBF /* PurchaseTrackerObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49891EB12094BEB600B9BCBF /* PurchaseTrackerObserver.swift */; };
 		498A894C2068FF5200457D66 /* TimelineFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 498A894B2068FF5200457D66 /* TimelineFeature.swift */; };
 		498A894D2068FF5200457D66 /* TimelineFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 498A894B2068FF5200457D66 /* TimelineFeature.swift */; };
 		498A894E2068FF5200457D66 /* TimelineFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 498A894B2068FF5200457D66 /* TimelineFeature.swift */; };
@@ -338,7 +341,7 @@
 		49935BF2206D250400CB2B5D /* TimeOrderedResultsController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49935BEE206D250400CB2B5D /* TimeOrderedResultsController.swift */; };
 		49966D8F200A63D1004C4AA0 /* AvailabilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49966D8E200A63D1004C4AA0 /* AvailabilityChecker.swift */; };
 		49966D91200A63EB004C4AA0 /* UserFeatureToggles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49966D90200A63EB004C4AA0 /* UserFeatureToggles.swift */; };
-		49966D93200A644A004C4AA0 /* PurchaseValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49966D92200A644A004C4AA0 /* PurchaseValidator.swift */; };
+		49966D93200A644A004C4AA0 /* PurchaseTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49966D92200A644A004C4AA0 /* PurchaseTracker.swift */; };
 		49966D95200A6472004C4AA0 /* UserDefaultsFeatureToggles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49966D94200A6472004C4AA0 /* UserDefaultsFeatureToggles.swift */; };
 		49966D97200A648A004C4AA0 /* DefaultAvailabilityChecker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49966D96200A648A004C4AA0 /* DefaultAvailabilityChecker.swift */; };
 		499F94EF1F93F84B0005B810 /* ActionLoggingDispatchObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 499F94EE1F93F84B0005B810 /* ActionLoggingDispatchObserver.swift */; };
@@ -376,7 +379,7 @@
 		49DB63FA205BD6DB00B9EE5D /* DebugReportingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB63F9205BD6DB00B9EE5D /* DebugReportingTests.swift */; };
 		49DB63FB205BD6DB00B9EE5D /* DebugReportingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB63F9205BD6DB00B9EE5D /* DebugReportingTests.swift */; };
 		49DB63FC205BD6DB00B9EE5D /* DebugReportingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB63F9205BD6DB00B9EE5D /* DebugReportingTests.swift */; };
-		49DB923C2073AF9C00F758DC /* StoreKitPurchaseValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49647D362037434B005F9825 /* StoreKitPurchaseValidator.swift */; };
+		49DB923C2073AF9C00F758DC /* StoreKitPurchaseTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49647D362037434B005F9825 /* StoreKitPurchaseTracker.swift */; };
 		49DB923E2073B4F500F758DC /* Product.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB923D2073B4F500F758DC /* Product.swift */; };
 		49DB923F2073B4F500F758DC /* Product.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB923D2073B4F500F758DC /* Product.swift */; };
 		49DB92402073B4F500F758DC /* Product.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB923D2073B4F500F758DC /* Product.swift */; };
@@ -457,7 +460,7 @@
 		495FD9FB20026A520007A427 /* ObserverSet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ObserverSet.swift; sourceTree = "<group>"; };
 		495FD9FD200363290007A427 /* FeaturePath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturePath.swift; sourceTree = "<group>"; };
 		496267B31F8BC14D002C83F2 /* README.md */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
-		49647D362037434B005F9825 /* StoreKitPurchaseValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKitPurchaseValidator.swift; sourceTree = "<group>"; };
+		49647D362037434B005F9825 /* StoreKitPurchaseTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreKitPurchaseTracker.swift; sourceTree = "<group>"; };
 		49647D3820374DE1005F9825 /* ActionStackEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionStackEntry.swift; sourceTree = "<group>"; };
 		49647D3A20384077005F9825 /* ActivitiesFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActivitiesFeature.swift; sourceTree = "<group>"; };
 		49647D3C203873C7005F9825 /* FlintFeatures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlintFeatures.swift; sourceTree = "<group>"; };
@@ -496,6 +499,7 @@
 		49819EBF1FC9C6D90013AF55 /* ConditionalFeatureDefinition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConditionalFeatureDefinition.swift; sourceTree = "<group>"; };
 		49839CE82046D1CA00C0AED3 /* DebugReportable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugReportable.swift; sourceTree = "<group>"; };
 		49839CEC2046D1D500C0AED3 /* DebugReporting.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DebugReporting.swift; sourceTree = "<group>"; };
+		49891EB12094BEB600B9BCBF /* PurchaseTrackerObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseTrackerObserver.swift; sourceTree = "<group>"; };
 		498A894B2068FF5200457D66 /* TimelineFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineFeature.swift; sourceTree = "<group>"; };
 		498A89572069695100457D66 /* FocusFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusFeature.swift; sourceTree = "<group>"; };
 		498AF6E0202729AE00AFE666 /* URLMapping.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLMapping.swift; sourceTree = "<group>"; };
@@ -512,7 +516,7 @@
 		49935BEE206D250400CB2B5D /* TimeOrderedResultsController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimeOrderedResultsController.swift; sourceTree = "<group>"; };
 		49966D8E200A63D1004C4AA0 /* AvailabilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AvailabilityChecker.swift; sourceTree = "<group>"; };
 		49966D90200A63EB004C4AA0 /* UserFeatureToggles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserFeatureToggles.swift; sourceTree = "<group>"; };
-		49966D92200A644A004C4AA0 /* PurchaseValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseValidator.swift; sourceTree = "<group>"; };
+		49966D92200A644A004C4AA0 /* PurchaseTracker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PurchaseTracker.swift; sourceTree = "<group>"; };
 		49966D94200A6472004C4AA0 /* UserDefaultsFeatureToggles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UserDefaultsFeatureToggles.swift; sourceTree = "<group>"; };
 		49966D96200A648A004C4AA0 /* DefaultAvailabilityChecker.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultAvailabilityChecker.swift; sourceTree = "<group>"; };
 		499F94EE1F93F84B0005B810 /* ActionLoggingDispatchObserver.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionLoggingDispatchObserver.swift; sourceTree = "<group>"; };
@@ -716,10 +720,11 @@
 				49F2CF231FF7EB2C004F16EF /* ConditionalActionBinding.swift */,
 				49966D8E200A63D1004C4AA0 /* AvailabilityChecker.swift */,
 				49966D90200A63EB004C4AA0 /* UserFeatureToggles.swift */,
-				49966D92200A644A004C4AA0 /* PurchaseValidator.swift */,
+				49966D92200A644A004C4AA0 /* PurchaseTracker.swift */,
 				49966D94200A6472004C4AA0 /* UserDefaultsFeatureToggles.swift */,
 				49966D96200A648A004C4AA0 /* DefaultAvailabilityChecker.swift */,
 				49935BCB206B901800CB2B5D /* ConditionalActionRequest.swift */,
+				49891EB12094BEB600B9BCBF /* PurchaseTrackerObserver.swift */,
 			);
 			path = "Conditional Features";
 			sourceTree = "<group>";
@@ -930,7 +935,7 @@
 		49DB92362073AF3100F758DC /* Purchases */ = {
 			isa = PBXGroup;
 			children = (
-				49647D362037434B005F9825 /* StoreKitPurchaseValidator.swift */,
+				49647D362037434B005F9825 /* StoreKitPurchaseTracker.swift */,
 				49DB92422073C67900F758DC /* PurchaseRequirement.swift */,
 				49DB923D2073B4F500F758DC /* Product.swift */,
 			);
@@ -1244,7 +1249,7 @@
 				498A894D2068FF5200457D66 /* TimelineFeature.swift in Sources */,
 				49935BEB206D23E400CB2B5D /* LIFOArrayQueue.swift in Sources */,
 				496F8FC5203EEBDA003AB29B /* FlintAppInfo.swift in Sources */,
-				496F8F85203EEBBA003AB29B /* PurchaseValidator.swift in Sources */,
+				496F8F85203EEBBA003AB29B /* PurchaseTracker.swift in Sources */,
 				496F8FCD203EEBDA003AB29B /* FeaturePath.swift in Sources */,
 				496F8FA3203EEBCD003AB29B /* ActivityActionDispatchObserver.swift in Sources */,
 				496F8FD3203EEBDA003AB29B /* Feature.swift in Sources */,
@@ -1283,9 +1288,10 @@
 				496F8F53203EEBB1003AB29B /* ActionLoggingDispatchObserver.swift in Sources */,
 				496F8F4C203EEBA5003AB29B /* ConsoleAnalyticsProvider.swift in Sources */,
 				49935BF0206D250400CB2B5D /* TimeOrderedResultsController.swift in Sources */,
-				496F8F88203EEBBA003AB29B /* StoreKitPurchaseValidator.swift in Sources */,
+				496F8F88203EEBBA003AB29B /* StoreKitPurchaseTracker.swift in Sources */,
 				496F8F87203EEBBA003AB29B /* DefaultAvailabilityChecker.swift in Sources */,
 				496F8FB0203EEBD3003AB29B /* URLMappingsBuilder.swift in Sources */,
+				49891EB32094BEB600B9BCBF /* PurchaseTrackerObserver.swift in Sources */,
 				496F8F5D203EEBB1003AB29B /* LoggerOutput.swift in Sources */,
 				49EA0BCF208B874900B9A32E /* SmartDispatchQueue.swift in Sources */,
 				4927FEF3208A3B8800163576 /* ActionSource.swift in Sources */,
@@ -1354,7 +1360,7 @@
 				498A894E2068FF5200457D66 /* TimelineFeature.swift in Sources */,
 				49935BEC206D23E400CB2B5D /* LIFOArrayQueue.swift in Sources */,
 				496F8FDA203EEBDA003AB29B /* FlintAppInfo.swift in Sources */,
-				496F8F8E203EEBBB003AB29B /* PurchaseValidator.swift in Sources */,
+				496F8F8E203EEBBB003AB29B /* PurchaseTracker.swift in Sources */,
 				496F8FE2203EEBDA003AB29B /* FeaturePath.swift in Sources */,
 				496F8FA6203EEBCE003AB29B /* ActivityActionDispatchObserver.swift in Sources */,
 				496F8FE8203EEBDA003AB29B /* Feature.swift in Sources */,
@@ -1393,9 +1399,10 @@
 				496F8F62203EEBB2003AB29B /* ActionLoggingDispatchObserver.swift in Sources */,
 				496F8F4F203EEBA6003AB29B /* ConsoleAnalyticsProvider.swift in Sources */,
 				49935BF1206D250400CB2B5D /* TimeOrderedResultsController.swift in Sources */,
-				496F8F91203EEBBB003AB29B /* StoreKitPurchaseValidator.swift in Sources */,
+				496F8F91203EEBBB003AB29B /* StoreKitPurchaseTracker.swift in Sources */,
 				496F8F90203EEBBB003AB29B /* DefaultAvailabilityChecker.swift in Sources */,
 				496F8FB8203EEBD4003AB29B /* URLMappingsBuilder.swift in Sources */,
+				49891EB42094BEB600B9BCBF /* PurchaseTrackerObserver.swift in Sources */,
 				496F8F6C203EEBB2003AB29B /* LoggerOutput.swift in Sources */,
 				49EA0BD0208B874900B9A32E /* SmartDispatchQueue.swift in Sources */,
 				4927FEF2208A3B8800163576 /* ActionSource.swift in Sources */,
@@ -1454,7 +1461,7 @@
 				49DB92462073C67900F758DC /* PurchaseRequirement.swift in Sources */,
 				49935BED206D23E400CB2B5D /* LIFOArrayQueue.swift in Sources */,
 				496F8FF6203EEBDB003AB29B /* FeatureGroup.swift in Sources */,
-				49DB923C2073AF9C00F758DC /* StoreKitPurchaseValidator.swift in Sources */,
+				49DB923C2073AF9C00F758DC /* StoreKitPurchaseTracker.swift in Sources */,
 				496F8FEC203EEBDB003AB29B /* ActionDispatcher.swift in Sources */,
 				4946FAC3208D16750097E10E /* ActionsBuilder.swift in Sources */,
 				496F8F7F203EEBB3003AB29B /* TopicPath.swift in Sources */,
@@ -1464,7 +1471,7 @@
 				496F8F73203EEBB2003AB29B /* TimelineEntry.swift in Sources */,
 				496F8FEF203EEBDB003AB29B /* FlintAppInfo.swift in Sources */,
 				498A894F2068FF5200457D66 /* TimelineFeature.swift in Sources */,
-				496F8F97203EEBBC003AB29B /* PurchaseValidator.swift in Sources */,
+				496F8F97203EEBBC003AB29B /* PurchaseTracker.swift in Sources */,
 				496F8FF7203EEBDB003AB29B /* FeaturePath.swift in Sources */,
 				498F97762077846000209633 /* FocusArea.swift in Sources */,
 				496F8FA9203EEBCF003AB29B /* ActivityActionDispatchObserver.swift in Sources */,
@@ -1538,7 +1545,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4948DBE6204D77A90030ED79 /* ActionContext.swift in Sources */,
-				49966D93200A644A004C4AA0 /* PurchaseValidator.swift in Sources */,
+				49966D93200A644A004C4AA0 /* PurchaseTracker.swift in Sources */,
 				4978E07420408C3B001D125D /* ActionStackTracker.swift in Sources */,
 				49647D3F203B117D005F9825 /* URLMapped.swift in Sources */,
 				495FD9FC20026A520007A427 /* ObserverSet.swift in Sources */,
@@ -1594,6 +1601,7 @@
 				498AF6E1202729AE00AFE666 /* URLMapping.swift in Sources */,
 				49819EBC1FC9C3660013AF55 /* ActionRequest.swift in Sources */,
 				49839CE92046D1CA00C0AED3 /* DebugReportable.swift in Sources */,
+				49891EB22094BEB600B9BCBF /* PurchaseTrackerObserver.swift in Sources */,
 				4921AC0920371B15003465E5 /* ContextSpecificLogger.swift in Sources */,
 				493572D41FC9D284003AD465 /* FeatureGroup.swift in Sources */,
 				49C9C37A1FFD317800E4D500 /* TopicPath+Extensions.swift in Sources */,
@@ -1603,7 +1611,7 @@
 				49A999FA1FF7FA6700A64E8C /* AnalyticsReporting.swift in Sources */,
 				4976923B201F3CBE00F97BD5 /* URLMappingsBuilder.swift in Sources */,
 				495FD9FE200363290007A427 /* FeaturePath.swift in Sources */,
-				49647D372037434B005F9825 /* StoreKitPurchaseValidator.swift in Sources */,
+				49647D372037434B005F9825 /* StoreKitPurchaseTracker.swift in Sources */,
 				49BC1C5720867C2400A7FC77 /* ActionStack.swift in Sources */,
 				49935BEF206D250400CB2B5D /* TimeOrderedResultsController.swift in Sources */,
 				49966D8F200A63D1004C4AA0 /* AvailabilityChecker.swift in Sources */,

--- a/FlintCore.xcodeproj/project.pbxproj
+++ b/FlintCore.xcodeproj/project.pbxproj
@@ -9,6 +9,15 @@
 /* Begin PBXBuildFile section */
 		490A21D7205B034F003E1D00 /* ZIPFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 4977DC7B205AECB500DAA0C8 /* ZIPFoundation.framework */; };
 		4914EFC72067C4D000FE0F41 /* Formatters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4914EFC62067C4D000FE0F41 /* Formatters.swift */; };
+		491533662093B14100B1E4D2 /* DefaultAvailabilityCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 491533652093B14100B1E4D2 /* DefaultAvailabilityCheckerTests.swift */; };
+		491533672093B14100B1E4D2 /* DefaultAvailabilityCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 491533652093B14100B1E4D2 /* DefaultAvailabilityCheckerTests.swift */; };
+		491533682093B14100B1E4D2 /* DefaultAvailabilityCheckerTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 491533652093B14100B1E4D2 /* DefaultAvailabilityCheckerTests.swift */; };
+		4915336B2093B7A800B1E4D2 /* MockUserToggles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4915336A2093B7A800B1E4D2 /* MockUserToggles.swift */; };
+		4915336C2093B7A800B1E4D2 /* MockUserToggles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4915336A2093B7A800B1E4D2 /* MockUserToggles.swift */; };
+		4915336D2093B7A800B1E4D2 /* MockUserToggles.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4915336A2093B7A800B1E4D2 /* MockUserToggles.swift */; };
+		4915336F2093B83300B1E4D2 /* MockPurchaseValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4915336E2093B83300B1E4D2 /* MockPurchaseValidator.swift */; };
+		491533702093B83300B1E4D2 /* MockPurchaseValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4915336E2093B83300B1E4D2 /* MockPurchaseValidator.swift */; };
+		491533712093B83300B1E4D2 /* MockPurchaseValidator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4915336E2093B83300B1E4D2 /* MockPurchaseValidator.swift */; };
 		4921AC0920371B15003465E5 /* ContextSpecificLogger.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4921AC0820371B15003465E5 /* ContextSpecificLogger.swift */; };
 		4921AC0B20371B83003465E5 /* TopicPath.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4921AC0A20371B83003465E5 /* TopicPath.swift */; };
 		4921AC0D20371D99003465E5 /* TimelineEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4921AC0C20371D99003465E5 /* TimelineEntry.swift */; };
@@ -417,6 +426,9 @@
 
 /* Begin PBXFileReference section */
 		4914EFC62067C4D000FE0F41 /* Formatters.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Formatters.swift; sourceTree = "<group>"; };
+		491533652093B14100B1E4D2 /* DefaultAvailabilityCheckerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultAvailabilityCheckerTests.swift; sourceTree = "<group>"; };
+		4915336A2093B7A800B1E4D2 /* MockUserToggles.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockUserToggles.swift; sourceTree = "<group>"; };
+		4915336E2093B83300B1E4D2 /* MockPurchaseValidator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockPurchaseValidator.swift; sourceTree = "<group>"; };
 		4921AC0820371B15003465E5 /* ContextSpecificLogger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContextSpecificLogger.swift; sourceTree = "<group>"; };
 		4921AC0A20371B83003465E5 /* TopicPath.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopicPath.swift; sourceTree = "<group>"; };
 		4921AC0C20371D99003465E5 /* TimelineEntry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineEntry.swift; sourceTree = "<group>"; };
@@ -600,6 +612,15 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		491533692093B6F700B1E4D2 /* Mocks and Helpers */ = {
+			isa = PBXGroup;
+			children = (
+				4915336A2093B7A800B1E4D2 /* MockUserToggles.swift */,
+				4915336E2093B83300B1E4D2 /* MockPurchaseValidator.swift */,
+			);
+			path = "Mocks and Helpers";
+			sourceTree = "<group>";
+		};
 		49298227205D677F00267A49 /* Test Features */ = {
 			isa = PBXGroup;
 			children = (
@@ -856,7 +877,9 @@
 		49CCF0B71F8BB1B200F7020E /* FlintCoreTests */ = {
 			isa = PBXGroup;
 			children = (
+				491533692093B6F700B1E4D2 /* Mocks and Helpers */,
 				49298227205D677F00267A49 /* Test Features */,
+				491533652093B14100B1E4D2 /* DefaultAvailabilityCheckerTests.swift */,
 				49DB63F9205BD6DB00B9EE5D /* DebugReportingTests.swift */,
 				49CCF0B81F8BB1B200F7020E /* FlintCoreTests.swift */,
 				49CCF0BA1F8BB1B200F7020E /* Info.plist */,
@@ -1297,9 +1320,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				491533672093B14100B1E4D2 /* DefaultAvailabilityCheckerTests.swift in Sources */,
 				49DB63FB205BD6DB00B9EE5D /* DebugReportingTests.swift in Sources */,
 				496F8F15203EE9EA003AB29B /* FlintCore_tvOSTests.swift in Sources */,
+				4915336C2093B7A800B1E4D2 /* MockUserToggles.swift in Sources */,
 				4929822A205D67A100267A49 /* DummyFeature.swift in Sources */,
+				491533702093B83300B1E4D2 /* MockPurchaseValidator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1404,9 +1430,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				491533682093B14100B1E4D2 /* DefaultAvailabilityCheckerTests.swift in Sources */,
 				49DB63FC205BD6DB00B9EE5D /* DebugReportingTests.swift in Sources */,
 				496F8F31203EEA06003AB29B /* FlintCore_macOSTests.swift in Sources */,
+				4915336D2093B7A800B1E4D2 /* MockUserToggles.swift in Sources */,
 				4929822B205D67A100267A49 /* DummyFeature.swift in Sources */,
+				491533712093B83300B1E4D2 /* MockPurchaseValidator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1611,9 +1640,12 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				491533662093B14100B1E4D2 /* DefaultAvailabilityCheckerTests.swift in Sources */,
 				49DB63FA205BD6DB00B9EE5D /* DebugReportingTests.swift in Sources */,
 				49CCF0B91F8BB1B200F7020E /* FlintCoreTests.swift in Sources */,
+				4915336B2093B7A800B1E4D2 /* MockUserToggles.swift in Sources */,
 				49298229205D67A100267A49 /* DummyFeature.swift in Sources */,
+				4915336F2093B83300B1E4D2 /* MockPurchaseValidator.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/FlintCore.xcodeproj/xcshareddata/xcschemes/FlintCore-iOS.xcscheme
+++ b/FlintCore.xcodeproj/xcshareddata/xcschemes/FlintCore-iOS.xcscheme
@@ -20,6 +20,20 @@
                ReferencedContainer = "container:FlintCore.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "49CCF0B21F8BB1B200F7020E"
+               BuildableName = "FlintCore-iOS-Tests.xctest"
+               BlueprintName = "FlintCore-iOS-Tests"
+               ReferencedContainer = "container:FlintCore.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
@@ -28,7 +42,6 @@
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       enableThreadSanitizer = "YES"
       enableUBSanitizer = "YES"
-      language = ""
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
          <TestableReference
@@ -58,7 +71,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      language = ""
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"

--- a/FlintCore/Activities/ActivitiesFeature.swift
+++ b/FlintCore/Activities/ActivitiesFeature.swift
@@ -13,7 +13,7 @@ import Foundation
 /// This provides actions used internally to publish and handle `NSUserActivity` for actions that opt-in to this by
 /// setting their `activityEligibility` property.
 public final class ActivitiesFeature: ConditionalFeature {
-    public static var availability: FeatureAvailability = .runtimeEvaluated
+    public static var availability: FeatureAvailability = .custom
     
     public static var description: String = "Automatic NSUserActivity publishing and handling for Handoff, Siri suggestions and Spotlight"
 

--- a/FlintCore/Conditional Features/AvailabilityChecker.swift
+++ b/FlintCore/Conditional Features/AvailabilityChecker.swift
@@ -9,8 +9,20 @@
 import Foundation
 
 /// You can customise the checking of purchased and user toggled conditional features by
-/// implementing this protocol 
+/// implementing this protocol.
+///
+/// Implementations must be safe to call from any thread or queue, so that callers
+/// testing `isAvailable` on a feature do not need to be concerned about this even if running
+/// on a background queue or an ActionSession that is not on the main queue.
+///
+/// - see: `DefaultAvailabilityChecker`
 public protocol AvailabilityChecker {
+
+    /// Return whether or not the specified feature is currently available.
+    /// Implementations must only return `true` if all ancesters of the feature are
+    /// also available.
+    /// - return: `nil` if the state of this feature or its ancestors is not yet known, or
+    /// a boolean value indicating whether or not this feature and all its ancestors are available.
     func isAvailable(_ feature: ConditionalFeatureDefinition.Type) -> Bool?
 }
 

--- a/FlintCore/Conditional Features/AvailabilityChecker.swift
+++ b/FlintCore/Conditional Features/AvailabilityChecker.swift
@@ -15,6 +15,9 @@ import Foundation
 /// testing `isAvailable` on a feature do not need to be concerned about this even if running
 /// on a background queue or an ActionSession that is not on the main queue.
 ///
+/// Implementations must also take care to examine the ancestors of features to ensure
+/// the correct result is returned from isAvailable.
+///
 /// - see: `DefaultAvailabilityChecker`
 public protocol AvailabilityChecker {
 

--- a/FlintCore/Conditional Features/ConditionalFeatureDefinition.swift
+++ b/FlintCore/Conditional Features/ConditionalFeatureDefinition.swift
@@ -29,7 +29,8 @@ public protocol ConditionalFeatureDefinition: FeatureDefinition {
 public extension ConditionalFeatureDefinition {
     /// Override this in your own features (with a more specific extension and YourFeature base class?)
     /// to use a custom checker instance that does not use the default validators
-    /// - note: Accesses to any properties that may change at runtime, e.g. `isAvailable` must only occur on the main thread.
+    /// - note: It is safe to invoke this from any thread or queue
+    /// - see: `AvailabilityChecker`
     static var isAvailable: Bool? {
         return Flint.availabilityChecker?.isAvailable(self)
     }

--- a/FlintCore/Conditional Features/DefaultAvailabilityChecker.swift
+++ b/FlintCore/Conditional Features/DefaultAvailabilityChecker.swift
@@ -19,7 +19,7 @@ import Foundation
 public class DefaultAvailabilityChecker: AvailabilityChecker {
     public let userFeatureToggles: UserFeatureToggles?
     public let purchaseValidator: PurchaseValidator?
-
+    
     /// Default shared instance using the default validators
 #if !os(watchOS)
     public static let instance = DefaultAvailabilityChecker(
@@ -31,6 +31,10 @@ public class DefaultAvailabilityChecker: AvailabilityChecker {
         purchaseValidator: nil)
 #endif
 
+    /// We store the last result of availability checks here
+    private var availabilityCache: [FeaturePath:Bool] = [:]
+    private let cacheAccessQueue = DispatchQueue(label: "tools.flint.availability-checker")
+
     /// Initialise the availability checker with the supplied feature toggle and purchase validator implementations.
     public init(userFeatureToggles: UserFeatureToggles?, purchaseValidator: PurchaseValidator?) {
         self.userFeatureToggles = userFeatureToggles
@@ -39,18 +43,67 @@ public class DefaultAvailabilityChecker: AvailabilityChecker {
     
     /// Return whether or not the feature is enabled, accordig to its `availability` type.
     public func isAvailable(_ feature: ConditionalFeatureDefinition.Type) -> Bool? {
+        return cacheAccessQueue.sync {
+            return _isAvailable(feature)
+        }
+    }
+    
+    private func _isAvailable(_ feature: ConditionalFeatureDefinition.Type) -> Bool? {
+        let featureIdentifier = feature.identifier
+        
+        // Fast path
+        if let cachedAvailable = availabilityCache[featureIdentifier] {
+            return cachedAvailable
+        }
+        
+        var available: Bool?
         switch feature.availability {
-            case .runtimeEvaluated:
-                preconditionFailure("Feature \(feature) is specified with availability \".runtimeEvaluated\" but has not overridden " +
+            case .custom:
+                preconditionFailure("Feature \(feature) is specified with availability \".custom\" but has not overridden " +
                                     "the \"isAvailable\" property to return whether or not it is available")
             case .userToggled:
-                return userFeatureToggles?.isEnabled(feature) ?? false
+                available = userFeatureToggles?.isEnabled(feature)
             case .purchaseRequired(let requirement):
                 if let validator = purchaseValidator {
-                    return requirement.isFulfilled(validator: validator)
+                    available = requirement.isFulfilled(validator: validator)
                 } else {
                     return nil
                 }
+        }
+        
+        guard var seemsAvailable = available else {
+            return nil
+        }
+        
+        if let conditionalParent = feature.parent as? ConditionalFeatureDefinition.Type {
+            if let parentAvailable = isAvailable(conditionalParent) {
+                seemsAvailable = seemsAvailable && parentAvailable
+            } else {
+                return nil
+            }
+        } else if let parent = feature.parent {
+            if let parentAvailable = _isAvailable(parent) {
+                seemsAvailable = seemsAvailable && parentAvailable
+            } else {
+                return nil
+            }
+        }
+        
+        availabilityCache[featureIdentifier] = seemsAvailable
+        return seemsAvailable
+    }
+
+    private func _isAvailable(_ feature: FeatureDefinition.Type) -> Bool? {
+        if let conditionalParent = feature.parent as? ConditionalFeatureDefinition.Type {
+            if let parentAvailable = _isAvailable(conditionalParent) {
+                return parentAvailable
+            } else {
+                return nil
+            }
+        } else if let parent = feature.parent {
+            return _isAvailable(parent)
+        } else {
+            return true // non-conditional features with no parent are always availabler
         }
     }
 }

--- a/FlintCore/Conditional Features/FeatureAvailability.swift
+++ b/FlintCore/Conditional Features/FeatureAvailability.swift
@@ -23,7 +23,7 @@ public enum FeatureAvailability {
     /// - see: `DefaultAvailabilityChecker`
     case userToggled
 
-    /// The deature uses some runtime feature toggling (A/B testing at the level of entire features), runtime
+    /// The feature uses some runtime feature toggling (A/B testing at the level of entire features), runtime
     /// tweaking of availability e.g. setting isAvailable at startup based on data, or remote feature control
-    case runtimeEvaluated
+    case custom
 }

--- a/FlintCore/Conditional Features/PurchaseTracker.swift
+++ b/FlintCore/Conditional Features/PurchaseTracker.swift
@@ -14,7 +14,13 @@ import Foundation
 ///
 /// Flint will call this multiple times for each productID that is required in a `PurchaseRequirement`,
 /// so implementations only need to respond to single product requests.
-public protocol PurchaseValidator {
+public protocol PurchaseTracker {
+
+    /// Call to add an observer for changes to purchases
+    func addObserver(_ observer: PurchaseTrackerObserver)
+
+    /// Call to remove an observer for changes to purchases
+    func removeObserver(_ observer: PurchaseTrackerObserver)
 
     /// Return whether or not the specified product ID has been paid for (or should be enabled) by the user.
     /// If the status is not yet known, the implementation can return `nil` to indicate this indeterminate status.

--- a/FlintCore/Conditional Features/PurchaseTrackerObserver.swift
+++ b/FlintCore/Conditional Features/PurchaseTrackerObserver.swift
@@ -1,0 +1,16 @@
+//
+//  PurchaseValidatorObserver.swift
+//  FlintCore
+//
+//  Created by Marc Palmer on 28/04/2018.
+//  Copyright © 2018 Montana Floss Co. Ltd. All rights reserved.
+//
+
+import Foundation
+
+/// The protocol for observers of changes to product purchase status
+/// - note: `@objc` only because of SR-55.
+/// - see: `PurchaseValidator`
+@objc public protocol PurchaseTrackerObserver {
+    func purchaseStatusDidChange(productID: String, isPurchased: Bool)
+}

--- a/FlintCore/Focus/FocusFeature.swift
+++ b/FlintCore/Focus/FocusFeature.swift
@@ -14,7 +14,7 @@ import Foundation
 final public class FocusFeature: ConditionalFeature {
     public static var description: String = "Focus allows the filtering of logs and timelines by Feature and Actions"
     
-    public static var availability: FeatureAvailability = .runtimeEvaluated
+    public static var availability: FeatureAvailability = .custom
 
     /// Set this to `false` at runtime to disable the Focus feature completely
     public static var isAvailable: Bool? = true

--- a/FlintCore/Purchases/PurchaseRequirement.swift
+++ b/FlintCore/Purchases/PurchaseRequirement.swift
@@ -55,41 +55,45 @@ public class PurchaseRequirement {
         self.dependencies = dependencies
     }
     
+    public convenience init(_ product: Product) {
+        self.init(products: [product], matchingCriteria: .all)
+    }
+    
     /// Call to see if this requirement and all dependent requirements are fulfilled
     /// - param validator: The validator to use to see if each product in a requirement has been purchased
-    public func isFulfilled(validator: PurchaseValidator) -> Bool {
-        let matched: Bool
+    public func isFulfilled(validator: PurchaseValidator) -> Bool? {
+        let matched: Bool?
         switch matchingCriteria {
             case .any:
-                var result = false
+                var result: Bool?
                 for product in products {
-                    result = validator.isPurchased(product.productID) ?? false
-                    if result {
+                    result = validator.isPurchased(product.productID)
+                    if result == true {
                         break
                     }
                 }
                 matched = result
             case .all:
-                var result = false
+                var result: Bool?
                 for product in products {
-                    result = validator.isPurchased(product.productID) ?? false
-                    if !result {
+                    result = validator.isPurchased(product.productID)
+                    if !(result == true) {
                         break
                     }
                 }
                 matched = result
         }
         
-        if matched {
+        if matched == true {
             guard let dependencies = dependencies else {
                 return matched
             }
             let firstFailing = dependencies.first(where: { requirement -> Bool in
-                return !requirement.isFulfilled(validator: validator)
+                return !(requirement.isFulfilled(validator: validator) == true)
             })
             return firstFailing == nil
         } else {
-            return false
+            return matched
         }
     }
 }

--- a/FlintCore/Purchases/PurchaseRequirement.swift
+++ b/FlintCore/Purchases/PurchaseRequirement.swift
@@ -61,7 +61,7 @@ public class PurchaseRequirement {
     
     /// Call to see if this requirement and all dependent requirements are fulfilled
     /// - param validator: The validator to use to see if each product in a requirement has been purchased
-    public func isFulfilled(validator: PurchaseValidator) -> Bool? {
+    public func isFulfilled(validator: PurchaseTracker) -> Bool? {
         let matched: Bool?
         switch matchingCriteria {
             case .any:

--- a/FlintCore/Purchases/StoreKitPurchaseTracker.swift
+++ b/FlintCore/Purchases/StoreKitPurchaseTracker.swift
@@ -1,5 +1,5 @@
 //
-//  StoreKitPurchaseValidator.swift
+//  StoreKitPurchaseTracker.swift
 //  FlintCore-iOS
 //
 //  Created by Marc Palmer on 16/02/2018.
@@ -14,7 +14,18 @@ import StoreKit
 /// Note that this code could be easily hacked on jailbroken devices. You may need to add your
 /// own app-specific logic to verify this so there isn't a single point of verification,
 /// and to check receipts.
-public class StoreKitPurchaseValidator: PurchaseValidator {
+public class StoreKitPurchaseTracker: PurchaseTracker {
+
+    private var observers = ObserverSet<PurchaseTrackerObserver>()
+
+    public func addObserver(_ observer: PurchaseTrackerObserver) {
+        let queue = SmartDispatchQueue(queue: .main, owner: self)
+        observers.add(observer, using: queue)
+    }
+    
+    public func removeObserver(_ observer: PurchaseTrackerObserver) {
+        observers.remove(observer)
+    }
 
     /// Called to see if a specific product has been purchased
     public func isPurchased(_ productID: String) -> Bool? {

--- a/FlintCore/Routes/RoutesFeature.swift
+++ b/FlintCore/Routes/RoutesFeature.swift
@@ -12,7 +12,7 @@ import Foundation
 /// dispatch the appropriate App action using a Presenter provided by a `PresentationRouter`
 /// which determines how your app will present the UI required for the action.
 final public class RoutesFeature: ConditionalFeature {
-    public static var availability: FeatureAvailability = .runtimeEvaluated
+    public static var availability: FeatureAvailability = .custom
     
     public static var description: String = "URL routes that support deep linking and custom URL schemes"
 

--- a/FlintCore/Timeline/TimelineFeature.swift
+++ b/FlintCore/Timeline/TimelineFeature.swift
@@ -16,7 +16,7 @@ import Foundation
 ///
 /// - see: `Timeline.snapshot()` for access to the data gathers.
 final public class TimelineFeature: ConditionalFeature {
-    public static var availability: FeatureAvailability = .runtimeEvaluated
+    public static var availability: FeatureAvailability = .custom
     
     public static var description: String = "Maintains an in-memory timeline of actions for debugging and reporting"
 

--- a/FlintCore/Utils/ObserverSet.swift
+++ b/FlintCore/Utils/ObserverSet.swift
@@ -11,7 +11,7 @@ import Foundation
 /// A set of observers that can be called on specific queues.
 class ObserverSet<T: AnyObject> {
     private struct ObserverQueuePair {
-        let observer: T
+        weak var observer: T?
         let queue: SmartDispatchQueue
     }
 
@@ -32,8 +32,10 @@ class ObserverSet<T: AnyObject> {
     /// Notify all the observers on their respective queues, asynchronously
     func notifyAsync(handler: @escaping (T) -> Void) {
         observers.forEach { pair in
-            pair.queue.syncOrAsyncIfDifferentQueue {
-                handler(pair.observer)
+            if let observer = pair.observer {
+                pair.queue.syncOrAsyncIfDifferentQueue {
+                    handler(observer)
+                }
             }
         }
     }
@@ -41,8 +43,10 @@ class ObserverSet<T: AnyObject> {
     /// Notify all the observers on their respective queues, synchronously
     func notifySync(handler: @escaping (T) -> Void) {
         observers.forEach { pair in
-            pair.queue.sync {
-                handler(pair.observer)
+            if let observer = pair.observer {
+                pair.queue.sync {
+                    handler(observer)
+                }
             }
         }
     }

--- a/FlintCore/Utils/TimeOrderedResultsController.swift
+++ b/FlintCore/Utils/TimeOrderedResultsController.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-@objc public protocol TimeOrderedResultsControllerDataSourceObserver: AnyObject {
+@objc public protocol TimeOrderedResultsControllerDataSourceObserver {
     /// Results are provided sorted in the natural time order of the data source
     func dataSourceNewResultsInserted(items: [Any])
     func dataSourceOldResultsLoaded(items: [Any])

--- a/FlintCoreTests/DefaultAvailabilityCheckerTests.swift
+++ b/FlintCoreTests/DefaultAvailabilityCheckerTests.swift
@@ -1,0 +1,96 @@
+//
+//  DefaultAvailabilityCheckerTests.swift
+//  FlintCore
+//
+//  Created by Marc Palmer on 27/04/2018.
+//  Copyright © 2018 Montana Floss Co. Ltd. All rights reserved.
+//
+
+import XCTest
+import FlintCore
+
+class DefaultAvailabilityCheckerTests: XCTestCase {
+ 
+    var checker: AvailabilityChecker!
+    var fakeToggles: MockUserToggles!
+    var fakePurchases: MockPurchaseValidator!
+
+    override func setUp() {
+        super.setUp()
+        
+        Flint.resetForTesting()
+
+        fakeToggles = MockUserToggles()
+        fakePurchases = MockPurchaseValidator()
+        checker = DefaultAvailabilityChecker(userFeatureToggles: fakeToggles, purchaseValidator: fakePurchases)
+    }
+    
+    override func tearDown() {
+        super.tearDown()
+    }
+    
+    func testAvailabilityOfRootFeatureThatIsUnavailableAndThenPurchased() {
+        // At first we don't know
+        XCTAssertTrue(checker.isAvailable(ConditionalFeatureA.self) == nil)
+
+        // Then we know we don't have it (data loaded)
+        fakePurchases.confirmNotPurchased(productA)
+        XCTAssertTrue(checker.isAvailable(ConditionalFeatureA.self) == false)
+
+        // Then we purchase
+        fakePurchases.makeFakePurchase(productA)
+        XCTAssertTrue(checker.isAvailable(ConditionalFeatureA.self) == true)
+    }
+
+    func testAvailabilityOfChildFeatureThatIsUnavailable() {
+        Flint.setup(ParentFeatureA.self)
+        
+        // At first we don't know
+        XCTAssertTrue(checker.isAvailable(ConditionalFeatureB.self) == nil)
+
+        // Then we know we don't have it (data loaded)
+        fakePurchases.confirmNotPurchased(productB)
+        XCTAssertTrue(checker.isAvailable(ConditionalFeatureB.self) == false)
+
+        // Then we purchase
+        fakePurchases.makeFakePurchase(productB)
+        XCTAssertTrue(checker.isAvailable(ConditionalFeatureB.self) == true)
+    }
+}
+
+fileprivate let productA = Product(name: "Product A", description: "This is product A", productID: "PROD-A")
+fileprivate let productB = Product(name: "Product B", description: "This is product B", productID: "PROD-B")
+
+final private class ConditionalFeatureA: ConditionalFeature {
+    static var description: String = ""
+    
+    static var availability: FeatureAvailability = .purchaseRequired(requirement: PurchaseRequirement(productA))
+    
+    static var isAvailable: Bool? = false
+
+    static func prepare(actions: FeatureActionsBuilder) {
+    }    
+}
+
+final private class ConditionalFeatureB: ConditionalFeature {
+    static var description: String = ""
+    
+    static var availability: FeatureAvailability = .purchaseRequired(requirement: PurchaseRequirement(productB))
+    
+    static var isAvailable: Bool? = false
+
+    static func prepare(actions: FeatureActionsBuilder) {
+    }
+}
+
+final private class ParentFeatureA: FeatureGroup {
+    static var description: String = ""
+
+    static var subfeatures: [FeatureDefinition.Type] = [
+        ConditionalFeatureB.self
+    ]
+    
+    static func prepare(actions: FeatureActionsBuilder) {
+    }
+}
+

--- a/FlintCoreTests/DefaultAvailabilityCheckerTests.swift
+++ b/FlintCoreTests/DefaultAvailabilityCheckerTests.swift
@@ -42,7 +42,7 @@ class DefaultAvailabilityCheckerTests: XCTestCase {
         XCTAssertTrue(checker.isAvailable(ConditionalFeatureA.self) == true)
     }
 
-    func testAvailabilityOfChildFeatureThatIsUnavailable() {
+    func testAvailabilityOfChildFeatureThatIsUnavailableAndThenPurchased() {
         Flint.setup(ParentFeatureA.self)
         
         // At first we don't know
@@ -56,10 +56,38 @@ class DefaultAvailabilityCheckerTests: XCTestCase {
         fakePurchases.makeFakePurchase(productB)
         XCTAssertTrue(checker.isAvailable(ConditionalFeatureB.self) == true)
     }
+
+    /// Verify that all the conditional features in the ancestry need to be purchased for
+    /// the child to be available.
+    func testAvailabilityOfChildFeatureWithParentThatIsUnavailableAndThenPurchased() {
+        Flint.setup(ConditionalParentFeatureA.self)
+        
+        // At first we don't know if the parent is purchased
+        XCTAssertTrue(checker.isAvailable(ConditionalParentFeatureA.self) == nil)
+
+        // Then we know we don't have it (data loaded)
+        fakePurchases.confirmNotPurchased(productC)
+        XCTAssertTrue(checker.isAvailable(ConditionalParentFeatureA.self) == false)
+
+        // Then we purchase the parent
+        fakePurchases.makeFakePurchase(productC)
+        XCTAssertTrue(checker.isAvailable(ConditionalParentFeatureA.self) == true)
+
+        // The child should still not be available, as the child itself has not been purchased
+        XCTAssertTrue(checker.isAvailable(ConditionalFeatureC.self) != true)
+
+        // Purchase the child
+        fakePurchases.makeFakePurchase(productD)
+
+        // The child should now be available
+        XCTAssertTrue(checker.isAvailable(ConditionalFeatureC.self) == true)
+    }
 }
 
 fileprivate let productA = Product(name: "Product A", description: "This is product A", productID: "PROD-A")
 fileprivate let productB = Product(name: "Product B", description: "This is product B", productID: "PROD-B")
+fileprivate let productC = Product(name: "Product C", description: "This is product C", productID: "PROD-C")
+fileprivate let productD = Product(name: "Product D", description: "This is product D", productID: "PROD-D")
 
 final private class ConditionalFeatureA: ConditionalFeature {
     static var description: String = ""
@@ -88,6 +116,30 @@ final private class ParentFeatureA: FeatureGroup {
 
     static var subfeatures: [FeatureDefinition.Type] = [
         ConditionalFeatureB.self
+    ]
+    
+    static func prepare(actions: FeatureActionsBuilder) {
+    }
+}
+
+final private class ConditionalFeatureC: ConditionalFeature {
+    static var description: String = ""
+    
+    static var availability: FeatureAvailability = .purchaseRequired(requirement: PurchaseRequirement(productD))
+    
+    static var isAvailable: Bool? = false
+
+    static func prepare(actions: FeatureActionsBuilder) {
+    }
+}
+
+final private class ConditionalParentFeatureA: FeatureGroup, ConditionalFeature {
+    static var availability: FeatureAvailability = .purchaseRequired(requirement: PurchaseRequirement(productC))
+    
+    static var description: String = ""
+    
+    static var subfeatures: [FeatureDefinition.Type] = [
+        ConditionalFeatureC.self
     ]
     
     static func prepare(actions: FeatureActionsBuilder) {

--- a/FlintCoreTests/FlintCoreTests.swift
+++ b/FlintCoreTests/FlintCoreTests.swift
@@ -18,7 +18,6 @@ class FlintCoreTests: XCTestCase {
     }
     
     override func tearDown() {
-        // Put teardown code here. This method is called after the invocation of each test method in the class.
         super.tearDown()
     }
     

--- a/FlintCoreTests/Mocks and Helpers/MockPurchaseValidator.swift
+++ b/FlintCoreTests/Mocks and Helpers/MockPurchaseValidator.swift
@@ -7,23 +7,52 @@
 //
 
 import Foundation
-import FlintCore
+@testable import FlintCore
 
-class MockPurchaseValidator: PurchaseValidator {
+/// A mock purchase validator that can simulate purchases or verification that items are not purchased.
+class MockPurchaseValidator: PurchaseTracker {
+    
+    var observers = ObserverSet<PurchaseTrackerObserver>()
     var fakePurchases: [String:Bool] = [:]
     
-    func confirmNotPurchased(_ product: Product) {
-        fakePurchases[product.productID] = false
+    func addObserver(_ observer: PurchaseTrackerObserver) {
+        observers.add(observer, using: SmartDispatchQueue(queue: .main, owner: self))
     }
     
-    func makeFakePurchase(_ product: Product) {
-        fakePurchases[product.productID] = true
+    func removeObserver(_ observer: PurchaseTrackerObserver) {
+        observers.remove(observer)
     }
     
-    func reset() {
+    /// Call this to fake confirmation that a purchase has not been made on this product.
+    /// Until the purchase subsystem has checked receipts, the status of such features is unknown.
+    public func confirmNotPurchased(_ product: Product) {
+        setPurchased(product, purchased: false)
+    }
+    
+    /// Call this to fake a purchase
+    public func makeFakePurchase(_ product: Product) {
+        setPurchased(product, purchased: true)
+    }
+    
+    public func reset() {
+        let copyOfPurchases = fakePurchases
         fakePurchases.removeAll()
+        
+        for (productID, purchased) in copyOfPurchases {
+            observers.notifySync { observer in
+                observer.purchaseStatusDidChange(productID: productID, isPurchased: purchased)
+            }
+        }
     }
     
+    private func setPurchased(_ product: Product, purchased: Bool) {
+        fakePurchases[product.productID] = purchased
+
+        observers.notifySync { observer in
+            observer.purchaseStatusDidChange(productID: product.productID, isPurchased: purchased)
+        }
+    }
+
     func isPurchased(_ productID: String) -> Bool? {
         return fakePurchases[productID]
     }

--- a/FlintCoreTests/Mocks and Helpers/MockPurchaseValidator.swift
+++ b/FlintCoreTests/Mocks and Helpers/MockPurchaseValidator.swift
@@ -1,0 +1,30 @@
+//
+//  MockPurchaseValidator.swift
+//  FlintCore
+//
+//  Created by Marc Palmer on 27/04/2018.
+//  Copyright © 2018 Montana Floss Co. Ltd. All rights reserved.
+//
+
+import Foundation
+import FlintCore
+
+class MockPurchaseValidator: PurchaseValidator {
+    var fakePurchases: [String:Bool] = [:]
+    
+    func confirmNotPurchased(_ product: Product) {
+        fakePurchases[product.productID] = false
+    }
+    
+    func makeFakePurchase(_ product: Product) {
+        fakePurchases[product.productID] = true
+    }
+    
+    func reset() {
+        fakePurchases.removeAll()
+    }
+    
+    func isPurchased(_ productID: String) -> Bool? {
+        return fakePurchases[productID]
+    }
+}

--- a/FlintCoreTests/Mocks and Helpers/MockUserToggles.swift
+++ b/FlintCoreTests/Mocks and Helpers/MockUserToggles.swift
@@ -1,0 +1,22 @@
+//
+//  MockUserToggles.swift
+//  FlintCore
+//
+//  Created by Marc Palmer on 27/04/2018.
+//  Copyright © 2018 Montana Floss Co. Ltd. All rights reserved.
+//
+
+import Foundation
+import FlintCore
+
+class MockUserToggles: UserFeatureToggles {
+    var toggles: [FeaturePath:Bool] = [:]
+    
+    func isEnabled(_ feature: ConditionalFeatureDefinition.Type) -> Bool {
+        return toggles[feature.identifier] ?? false
+    }
+    
+    func setEnabled(_ feature: ConditionalFeatureDefinition.Type, enabled: Bool) {
+        toggles[feature.identifier] = enabled
+   }
+}

--- a/FlintUI/Features/FocusLogDataAccessFeature.swift
+++ b/FlintUI/Features/FocusLogDataAccessFeature.swift
@@ -11,7 +11,7 @@ import FlintCore
 
 /// Provides the data for a UI that shows Focus Logs
 final public class FocusLogDataAccessFeature: ConditionalFeature {
-    public static var availability: FeatureAvailability = .runtimeEvaluated
+    public static var availability: FeatureAvailability = .custom
     
     public static var description: String = "Provides access to the Focus logs for presenting in a UI"
 

--- a/FlintUI/Features/LogBrowserFeature.swift
+++ b/FlintUI/Features/LogBrowserFeature.swift
@@ -14,7 +14,7 @@ import FlintCore
 final public class LogBrowserFeature: ConditionalFeature {
     public static var description: String = "UI for browsing the Focus logs"
     
-    public static var availability: FeatureAvailability = .runtimeEvaluated
+    public static var availability: FeatureAvailability = .custom
     public static var isAvailable: Bool? { return FocusFeature.isAvailable }
 
     public static let show = action(ShowLogBrowserAction.self)

--- a/FlintUI/Features/TimelineBrowserFeature.swift
+++ b/FlintUI/Features/TimelineBrowserFeature.swift
@@ -14,7 +14,7 @@ import FlintCore
 final public class TimelineBrowserFeature: ConditionalFeature {
     public static var description: String = "UI for browsing the Timeline"
     
-    public static var availability: FeatureAvailability = .runtimeEvaluated
+    public static var availability: FeatureAvailability = .custom
     public static var isAvailable: Bool? { return TimelineFeature.isAvailable }
 
     public static let show = action(ShowTimelineBrowserAction.self)

--- a/FlintUI/Features/TimelineDataAccessFeature.swift
+++ b/FlintUI/Features/TimelineDataAccessFeature.swift
@@ -11,7 +11,7 @@ import FlintCore
 
 /// A feature that provides access to the Timeline for presenting in a UI
 final public class TimelineDataAccessFeature: ConditionalFeature {
-    public static var availability: FeatureAvailability = .runtimeEvaluated
+    public static var availability: FeatureAvailability = .custom
     
     public static var description: String = "Provides access to the timeline of actions for debugging and reporting"
 


### PR DESCRIPTION
In order to tackle threadsafety, asynchronous changes to availability (e.g. purchase verifications) and support hierarchical feature availability (all ancestors must be available for a grandchild to be available too).

Work involved:

* the name of "runtimeEvaluated" to "custom", as it is less confusing
* the return of the availability checker and purchase validators all have too be `Bool?` so we don't lose information about indeterminate states
* added observing to the purchase tracker 
* the addition of hierarchical testing of availability
* unit tests!