### PR TITLE
Xcode 9.4 chokes on missing “#if available”

### DIFF
--- a/FlintCore/Core/Flint.swift
+++ b/FlintCore/Core/Flint.swift
@@ -298,9 +298,11 @@ final public class Flint {
 #endif
 
 #if canImport(ClassKit)
-                    // Check for a ClassKit activity
-                    if activity.isClassKitDeepLink {
-                        source = .continueActivity(type: .classKit)
+                    if #available(iOS 11.3, *) {
+                        // Check for a ClassKit activity
+                        if activity.isClassKitDeepLink {
+                            source = .continueActivity(type: .classKit)
+                        }
                     }
 #endif
             }


### PR DESCRIPTION
This doesn't make much sense to me, as we compiled fine on 9.3 and ClassKit was available but... ho hum. Xcode 9.4 fails to compile without this added.