### PR TITLE
Add support for Contacts permission and clean up some stuff

### DIFF
--- a/FlintCore.xcodeproj/project.pbxproj
+++ b/FlintCore.xcodeproj/project.pbxproj
@@ -981,6 +981,7 @@
 				496136C4209900E200291885 /* CameraPermissionAdapter.swift */,
 				496136CE2099013000291885 /* PhotosPermissionAdapter.swift */,
 				496136D32099015900291885 /* LocationPermissionAdapter.swift */,
+				494C278A20BEF11900053FF7 /* ContactsPermissionAdapter.swift */,
 				496136D82099017400291885 /* DefaultPermissionChecker.swift */,
 				496136DD2099028F00291885 /* LocationUsage.swift */,
 				49DFB7C420A2DF8500D3AE68 /* AuthorisationController.swift */,
@@ -988,7 +989,6 @@
 				49DFB7CE20A2DFD500D3AE68 /* PermissionAuthorisationCoordinator.swift */,
 				49DFB7D320A2E00500D3AE68 /* SystemPermissionRequestAction.swift */,
 				49DFB7DD20A3464800D3AE68 /* FeaturePermissionRequirements.swift */,
-				494C278A20BEF11900053FF7 /* ContactsPermissionAdapter.swift */,
 			);
 			path = Permissions;
 			sourceTree = "<group>";

--- a/FlintCore.xcodeproj/project.pbxproj
+++ b/FlintCore.xcodeproj/project.pbxproj
@@ -81,6 +81,10 @@
 		4946FAC7208E23740097E10E /* ActionPerformOutcome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4946FAC4208E23740097E10E /* ActionPerformOutcome.swift */; };
 		4946FAC8208E23740097E10E /* ActionPerformOutcome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4946FAC4208E23740097E10E /* ActionPerformOutcome.swift */; };
 		4948DBE6204D77A90030ED79 /* ActionContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4948DBE5204D77A90030ED79 /* ActionContext.swift */; };
+		494C278B20BEF11900053FF7 /* ContactsPermissionAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494C278A20BEF11900053FF7 /* ContactsPermissionAdapter.swift */; };
+		494C278C20BEF11900053FF7 /* ContactsPermissionAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494C278A20BEF11900053FF7 /* ContactsPermissionAdapter.swift */; };
+		494C278D20BEF11900053FF7 /* ContactsPermissionAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494C278A20BEF11900053FF7 /* ContactsPermissionAdapter.swift */; };
+		494C278E20BEF11900053FF7 /* ContactsPermissionAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494C278A20BEF11900053FF7 /* ContactsPermissionAdapter.swift */; };
 		494F590B2098A9F70075E7EE /* Platform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494F590A2098A9F70075E7EE /* Platform.swift */; };
 		494F590C2098A9F70075E7EE /* Platform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494F590A2098A9F70075E7EE /* Platform.swift */; };
 		494F590D2098A9F70075E7EE /* Platform.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494F590A2098A9F70075E7EE /* Platform.swift */; };
@@ -692,6 +696,7 @@
 		4946FABF208D16750097E10E /* ActionsBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionsBuilder.swift; sourceTree = "<group>"; };
 		4946FAC4208E23740097E10E /* ActionPerformOutcome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionPerformOutcome.swift; sourceTree = "<group>"; };
 		4948DBE5204D77A90030ED79 /* ActionContext.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionContext.swift; sourceTree = "<group>"; };
+		494C278A20BEF11900053FF7 /* ContactsPermissionAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContactsPermissionAdapter.swift; sourceTree = "<group>"; };
 		494F590A2098A9F70075E7EE /* Platform.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Platform.swift; sourceTree = "<group>"; };
 		494F590F2098AA140075E7EE /* OperatingSystemVersion+Utilities.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "OperatingSystemVersion+Utilities.swift"; sourceTree = "<group>"; };
 		494F59142098AA280075E7EE /* PlatformVersionConstraint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlatformVersionConstraint.swift; sourceTree = "<group>"; };
@@ -983,6 +988,7 @@
 				49DFB7CE20A2DFD500D3AE68 /* PermissionAuthorisationCoordinator.swift */,
 				49DFB7D320A2E00500D3AE68 /* SystemPermissionRequestAction.swift */,
 				49DFB7DD20A3464800D3AE68 /* FeaturePermissionRequirements.swift */,
+				494C278A20BEF11900053FF7 /* ContactsPermissionAdapter.swift */,
 			);
 			path = Permissions;
 			sourceTree = "<group>";
@@ -1719,6 +1725,7 @@
 				496F8FD3203EEBDA003AB29B /* Feature.swift in Sources */,
 				496F8FAB203EEBD3003AB29B /* LinkCreator.swift in Sources */,
 				4927FEF9208A537100163576 /* PublishCurrentActionActivityAction.swift in Sources */,
+				494C278C20BEF11900053FF7 /* ContactsPermissionAdapter.swift in Sources */,
 				49FC460120A46F2E00679F97 /* LogEvent.swift in Sources */,
 				496136D52099015900291885 /* LocationPermissionAdapter.swift in Sources */,
 				498F976F207783C500209633 /* FocusLogging.swift in Sources */,
@@ -1880,6 +1887,7 @@
 				496F8FE8203EEBDA003AB29B /* Feature.swift in Sources */,
 				496F8FB3203EEBD4003AB29B /* LinkCreator.swift in Sources */,
 				4927FEFA208A537100163576 /* PublishCurrentActionActivityAction.swift in Sources */,
+				494C278D20BEF11900053FF7 /* ContactsPermissionAdapter.swift in Sources */,
 				49FC460220A46F2F00679F97 /* LogEvent.swift in Sources */,
 				496136D62099015900291885 /* LocationPermissionAdapter.swift in Sources */,
 				498F9770207783C500209633 /* FocusLogging.swift in Sources */,
@@ -2041,6 +2049,7 @@
 				494F59222098AA5D0075E7EE /* DeclaredFeatureConstraints.swift in Sources */,
 				498A894F2068FF5200457D66 /* TimelineFeature.swift in Sources */,
 				496F8F97203EEBBC003AB29B /* PurchaseTracker.swift in Sources */,
+				494C278E20BEF11900053FF7 /* ContactsPermissionAdapter.swift in Sources */,
 				496136E12099028F00291885 /* LocationUsage.swift in Sources */,
 				496F8FF7203EEBDB003AB29B /* FeaturePath.swift in Sources */,
 				494F592C2098AB390075E7EE /* FeaturePreconditionEvaluator.swift in Sources */,
@@ -2195,6 +2204,7 @@
 				49A999FC1FF7FC5200A64E8C /* ConsoleAnalyticsProvider.swift in Sources */,
 				496136CF2099013000291885 /* PhotosPermissionAdapter.swift in Sources */,
 				49298241205FCC6000267A49 /* ActionOutcome.swift in Sources */,
+				494C278B20BEF11900053FF7 /* ContactsPermissionAdapter.swift in Sources */,
 				494F593D2098ABB20075E7EE /* UserTogglePreconditionEvaluator.swift in Sources */,
 				49935BCA206AA80A00CB2B5D /* LogEvent.swift in Sources */,
 				4927FEF8208A537100163576 /* PublishCurrentActionActivityAction.swift in Sources */,

--- a/FlintCore/Conditional Features/ConditionalFeature.swift
+++ b/FlintCore/Conditional Features/ConditionalFeature.swift
@@ -109,12 +109,12 @@ public extension ConditionalFeature {
     /// Request permissions for all unauthorised permission requirements, using the supplied presenter
     public static func permissionAuthorisationController(using coordinator: PermissionAuthorisationCoordinator?) -> AuthorisationController? {
         let constraints = Flint.constraintsEvaluator.evaluate(for: self)
-        guard constraints.permissions.notSatisfied.count > 0 else {
+        guard constraints.permissions.notDetermined.count > 0 else {
             return nil
         }
         
         return DefaultAuthorisationController(coordinator: coordinator,
-                                              permissions: Set(constraints.permissions.notSatisfied.map { $0.constraint }))
+                                              permissions: Set(constraints.permissions.notDetermined.map { $0.constraint }))
     }
     
     /// Function for binding a conditional feature and action pair, to restrict how this can be done externally by app code.

--- a/FlintCore/Constraints/Permissions/CameraPermissionAdapter.swift
+++ b/FlintCore/Constraints/Permissions/CameraPermissionAdapter.swift
@@ -7,37 +7,49 @@
 //
 
 import Foundation
-#if canImport(AVFoundation)
 import AVFoundation
-#endif
 
 /// Checks and authorises access to the Camera on supported platforms
+///
+/// Supports: iOS 7+, macOS *, watchOS ⛔️, tvOS ⛔️
 class CameraPermissionAdapter: SystemPermissionAdapter {
-    let permission: SystemPermissionConstraint = .camera
+    static var isSupported: Bool {
+#if os(iOS) || os(macOS)
+        return true
+#else
+        return false
+#endif
+    }
+    
+    static func createAdapters() -> [SystemPermissionAdapter] {
+        return [CameraPermissionAdapter(permission: .camera)]
+    }
+
+    let permission: SystemPermissionConstraint
     let usageDescriptionKey: String = "NSCameraUsageDescription"
 
     var status: SystemPermissionStatus {
 #if os(iOS)
-#if canImport(AVFoundation)
         switch AVCaptureDevice.authorizationStatus(for: .video) {
             case .authorized: return .authorized
             case .denied: return .denied
             case .notDetermined: return .notDetermined
             case .restricted: return .restricted
         }
-#else
-        return .unsupported
-#endif
 #elseif os(macOS)
+        // There are no permissions!
         return .authorized
 #else
         return .unsupported
 #endif
     }
 
+    required init(permission: SystemPermissionConstraint) {
+        self.permission = permission
+    }
+    
     func requestAuthorisation(completion: @escaping (_ adapter: SystemPermissionAdapter, _ status: SystemPermissionStatus) -> Void) {
 #if os(iOS)
-#if canImport(AVFoundation)
         guard status == .notDetermined else {
             return
         }
@@ -49,7 +61,6 @@ class CameraPermissionAdapter: SystemPermissionAdapter {
         return .authorized
 #else
         return .unsupported
-#endif
 #endif
     }
 }

--- a/FlintCore/Constraints/Permissions/CameraPermissionAdapter.swift
+++ b/FlintCore/Constraints/Permissions/CameraPermissionAdapter.swift
@@ -51,6 +51,7 @@ class CameraPermissionAdapter: SystemPermissionAdapter {
     func requestAuthorisation(completion: @escaping (_ adapter: SystemPermissionAdapter, _ status: SystemPermissionStatus) -> Void) {
 #if os(iOS)
         guard status == .notDetermined else {
+            completion(self, .notDetermined)
             return
         }
         
@@ -58,9 +59,9 @@ class CameraPermissionAdapter: SystemPermissionAdapter {
             completion(self, granted ? .authorized : .denied)
         }
 #elseif os(macOS)
-        return .authorized
+        completion(self, .authorized)
 #else
-        return .unsupported
+        completion(self, .unsupported)
 #endif
     }
 }

--- a/FlintCore/Constraints/Permissions/ContactsPermissionAdapter.swift
+++ b/FlintCore/Constraints/Permissions/ContactsPermissionAdapter.swift
@@ -37,12 +37,12 @@ class ContactsPermissionAdapter: SystemPermissionAdapter {
     }
 
     let permission: SystemPermissionConstraint
-    let usageDescriptionKey: String = "NSPhotoLibraryUsageDescription"
+    let usageDescriptionKey: String = "NSContactsUsageDescription"
     let contactStore = CNContactStore()
     let entityType: CNEntityType
 
     var status: SystemPermissionStatus {
-#if canImport(Photos)
+#if canImport(Contacts)
         if #available(iOS 9, macOS 10.11, watchOS 2, *) {
             return authStatusToPermissionStatus(CNContactStore.authorizationStatus(for: entityType))
         } else {

--- a/FlintCore/Constraints/Permissions/ContactsPermissionAdapter.swift
+++ b/FlintCore/Constraints/Permissions/ContactsPermissionAdapter.swift
@@ -38,8 +38,10 @@ class ContactsPermissionAdapter: SystemPermissionAdapter {
 
     let permission: SystemPermissionConstraint
     let usageDescriptionKey: String = "NSContactsUsageDescription"
-    let contactStore = CNContactStore()
+#if canImport(Contacts)
+    let contactStore: CNContactStore = CNContactStore()
     let entityType: CNEntityType
+#endif
 
     var status: SystemPermissionStatus {
 #if canImport(Contacts)
@@ -48,6 +50,8 @@ class ContactsPermissionAdapter: SystemPermissionAdapter {
         } else {
             return .unsupported
         }
+#else
+        return .unsupported
 #endif
     }
     
@@ -55,9 +59,11 @@ class ContactsPermissionAdapter: SystemPermissionAdapter {
         guard case let .contacts(entityType) = permission else {
             preconditionFailure("Cannot create a ContactsPermissionAdapter with permission type \(permission)")
         }
+#if canImport(Contacts)
         switch entityType {
             case .contacts: self.entityType = .contacts
         }
+#endif
         self.permission = permission
     }
     
@@ -67,9 +73,11 @@ class ContactsPermissionAdapter: SystemPermissionAdapter {
             return
         }
         
+#if canImport(Contacts)
         contactStore.requestAccess(for: .contacts) { (_, _) in
             completion(self, self.status)
         }
+#endif
 #else
         completion(self, .unsupported)
 #endif

--- a/FlintCore/Constraints/Permissions/ContactsPermissionAdapter.swift
+++ b/FlintCore/Constraints/Permissions/ContactsPermissionAdapter.swift
@@ -1,0 +1,93 @@
+//
+//  ContactsPermissionAdapter.swift
+//  FlintCore
+//
+//  Created by Marc Palmer on 30/05/2018.
+//  Copyright © 2018 Montana Floss Co. Ltd. All rights reserved.
+//
+
+import Foundation
+#if canImport(Contacts)
+import Contacts
+#endif
+
+/// Defines the type of Contacts entity for which Flint will request access
+public enum ContactsEntity: Hashable {
+    case contacts
+}
+
+/// Checks and authorises access to the Contacts on supported platforms
+///
+/// Support: iOS 9+, macOS 10.11+, watchOS 2+, tvOS ⛔️
+class ContactsPermissionAdapter: SystemPermissionAdapter {
+    static var isSupported: Bool {
+#if !os(tvOS)
+        if #available(iOS 9, macOS 10.11, watchOS 2, *) {
+            return true
+        } else {
+            return false
+        }
+#else
+        return false
+#endif
+    }
+
+    static func createAdapters() -> [SystemPermissionAdapter] {
+        return [ContactsPermissionAdapter(permission: .contacts(entity: .contacts))]
+    }
+
+    let permission: SystemPermissionConstraint
+    let usageDescriptionKey: String = "NSPhotoLibraryUsageDescription"
+    let contactStore = CNContactStore()
+    let entityType: CNEntityType
+
+    var status: SystemPermissionStatus {
+#if canImport(Photos)
+        if #available(iOS 9, macOS 10.11, watchOS 2, *) {
+            return authStatusToPermissionStatus(CNContactStore.authorizationStatus(for: entityType))
+        } else {
+            return .unsupported
+        }
+#endif
+    }
+    
+    required init(permission: SystemPermissionConstraint) {
+        guard case let .contacts(entityType) = permission else {
+            preconditionFailure("Cannot create a ContactsPermissionAdapter with permission type \(permission)")
+        }
+        switch entityType {
+            case .contacts: self.entityType = .contacts
+        }
+        self.permission = permission
+    }
+    
+    func requestAuthorisation(completion: @escaping (_ adapter: SystemPermissionAdapter, _ status: SystemPermissionStatus) -> Void) {
+#if !os(tvOS)
+        guard status == .notDetermined else {
+            return
+        }
+        
+        contactStore.requestAccess(for: .contacts) { (_, _) in
+            completion(self, self.status)
+        }
+#else
+        completion(self, .unsupported)
+#endif
+    }
+
+#if canImport(Contacts)
+    @available(iOS 9, macOS 10.11, watchOS 2, *)
+    func authStatusToPermissionStatus(_ authStatus: CNAuthorizationStatus) -> SystemPermissionStatus {
+#if os(tvOS)
+        return .unsupported
+#else
+        switch authStatus {
+            case .authorized: return .authorized
+            case .denied: return .denied
+            case .notDetermined: return .notDetermined
+            case .restricted: return .restricted
+        }
+#endif
+    }
+#endif
+}

--- a/FlintCore/Constraints/Permissions/DefaultAuthorisationController.swift
+++ b/FlintCore/Constraints/Permissions/DefaultAuthorisationController.swift
@@ -65,13 +65,18 @@ class DefaultAuthorisationController: AuthorisationController {
                     if status != .authorized {
                         strongSelf.permissionsNotAuthorized.append(permission)
                     }
-                    strongSelf.coordinator?.didRequestPermission(for: permission, status: status, completion: { shouldCancel in
-                        if !shouldCancel {
-                            strongSelf.next()
-                        } else {
-                            strongSelf.cancel()
-                        }
-                    })
+                    if let coordinator = strongSelf.coordinator {
+                        coordinator.didRequestPermission(for: permission, status: status, completion: { shouldCancel in
+                            if !shouldCancel {
+                                strongSelf.next()
+                            } else {
+                                strongSelf.cancel()
+                            }
+                        })
+                    } else {
+                        // Assume if there is no coordinator that we'll just carry on to the next
+                        strongSelf.next()
+                    }
                 }
             }
 

--- a/FlintCore/Constraints/Permissions/LocationPermissionAdapter.swift
+++ b/FlintCore/Constraints/Permissions/LocationPermissionAdapter.swift
@@ -37,7 +37,7 @@ import CoreLocation
     let locationManager = CLLocationManager()
     
     let permission: SystemPermissionConstraint
-    let usageDescriptionKey: String = "NSLocationWhenInUseUsageDescription"
+    let usageDescriptionKey: String
     var pendingCompletions: [(_ adapter: SystemPermissionAdapter, _ status: SystemPermissionStatus) -> Void] = []
     
     var status: SystemPermissionStatus {
@@ -55,6 +55,11 @@ import CoreLocation
         }
 #endif
         self.permission = permission
+
+        switch usage {
+            case .whenInUse: usageDescriptionKey = "NSLocationWhenInUseUsageDescription"
+            case .always: usageDescriptionKey = "NSLocationAlwaysUsageDescription"
+        }
         
         super.init()
         

--- a/FlintCore/Constraints/Permissions/LocationPermissionAdapter.swift
+++ b/FlintCore/Constraints/Permissions/LocationPermissionAdapter.swift
@@ -10,8 +10,30 @@ import Foundation
 import CoreLocation
 
 /// Checks and authorises access to the user's location on supported platforms
-/// !!! TODO: What about macOS?
+///
+/// Supports: iOS 2+, macOS 10.6+, watchOS 2+, tvOS 9+
 @objc class LocationPermissionAdapter: NSObject, SystemPermissionAdapter, CLLocationManagerDelegate {
+    static var isSupported: Bool {
+        if #available(iOS 2, macOS 10.6, watchOS 2, tvOS 9, *) {
+            return true
+        } else {
+            return false
+        }
+    }
+    
+    static func createAdapters() -> [SystemPermissionAdapter] {
+        var results: [SystemPermissionAdapter] = []
+#if canImport(CoreLocation)
+        // One for whenInUse checking
+        results.append(LocationPermissionAdapter(permission: .location(usage: .whenInUse)))
+#if os(iOS) || os(watchOS)
+        // One for always checking
+        results.append(LocationPermissionAdapter(permission: .location(usage: .always)))
+#endif
+#endif
+        return results
+    }
+
     let locationManager = CLLocationManager()
     
     let permission: SystemPermissionConstraint
@@ -22,17 +44,20 @@ import CoreLocation
         return authStatusToPermissionStatus(CLLocationManager.authorizationStatus())
     }
     
-    public init(usage: LocationUsage) {
+    required init(permission: SystemPermissionConstraint) {
+        guard case let .location(usage) = permission else {
+            preconditionFailure("Cannot use LocationPermissionAdapter with \(permission)")
+        }
+
 #if !os(iOS)
         if .always == usage {
             fatalError("Location usage cannot be 'always' on this platform.")
         }
 #endif
-        switch usage {
-            case .always: permission = .location(usage: .always)
-            case .whenInUse: permission = .location(usage: .whenInUse)
-        }
+        self.permission = permission
+        
         super.init()
+        
         locationManager.delegate = self
     }
     

--- a/FlintCore/Constraints/Permissions/PhotosPermissionAdapter.swift
+++ b/FlintCore/Constraints/Permissions/PhotosPermissionAdapter.swift
@@ -12,8 +12,26 @@ import Photos
 #endif
 
 /// Checks and authorises access to the Photo library on supported platforms
+///
+/// Supports: iOS 8+, macOS 10.13+, watchOS ⛔️, tvOS 10+
 class PhotosPermissionAdapter: SystemPermissionAdapter {
-    let permission: SystemPermissionConstraint = .photos
+    static var isSupported: Bool {
+#if os(watchOS)
+        return false
+#else
+        if #available(iOS 8, macOS 10.13, tvOS 10, *) {
+            return true
+        } else {
+            return false
+        }
+#endif
+    }
+
+    static func createAdapters() -> [SystemPermissionAdapter] {
+        return [PhotosPermissionAdapter(permission: .photos)]
+    }
+
+    let permission: SystemPermissionConstraint
     let usageDescriptionKey: String = "NSPhotoLibraryUsageDescription"
 
     var status: SystemPermissionStatus {
@@ -28,8 +46,11 @@ class PhotosPermissionAdapter: SystemPermissionAdapter {
 #endif
     }
     
+    required init(permission: SystemPermissionConstraint) {
+        self.permission = permission
+    }
+    
     func requestAuthorisation(completion: @escaping (_ adapter: SystemPermissionAdapter, _ status: SystemPermissionStatus) -> Void) {
-#if os(iOS)
 #if canImport(Photos)
         guard status == .notDetermined else {
             return
@@ -38,7 +59,6 @@ class PhotosPermissionAdapter: SystemPermissionAdapter {
         PHPhotoLibrary.requestAuthorization({status in
             completion(self, self.authStatusToPermissionStatus(status))
         })
-#endif
 #endif
     }
 

--- a/FlintCore/Constraints/Permissions/PhotosPermissionAdapter.swift
+++ b/FlintCore/Constraints/Permissions/PhotosPermissionAdapter.swift
@@ -56,9 +56,13 @@ class PhotosPermissionAdapter: SystemPermissionAdapter {
             return
         }
         
-        PHPhotoLibrary.requestAuthorization({status in
-            completion(self, self.authStatusToPermissionStatus(status))
-        })
+        if #available(iOS 8, tvOS 10, macOS 10.13, *) {
+            PHPhotoLibrary.requestAuthorization({status in
+                completion(self, self.authStatusToPermissionStatus(status))
+            })
+        } else {
+                completion(self, .unsupported)
+        }
 #endif
     }
 

--- a/FlintCore/Constraints/Permissions/SystemPermissionAdapter.swift
+++ b/FlintCore/Constraints/Permissions/SystemPermissionAdapter.swift
@@ -9,7 +9,18 @@
 import Foundation
 
 /// The interface for components that provide access to underlying system permissions.
-public protocol SystemPermissionAdapter {
+public protocol SystemPermissionAdapter: AnyObject {
+    /// Must return `true` only if this permission is available on the current runtime platform and device.
+    /// This is used by the permission checker to avoid instantiating adapters that are not relevant, and to avoid
+    /// access to APIs that are not available on all devices. Without this the permission checker has to have all
+    /// the #if os(xxx) checks, which is invasive
+    static var isSupported: Bool { get }
+    
+    /// Called to create all the adapters supported by this type of permission.
+    /// This is called to enable adapters that have multiple variants to create all the appropriate
+    /// objects for the current platform.
+    static func createAdapters() -> [SystemPermissionAdapter]
+
     /// The permission this adapter can verify and authorise
     var permission: SystemPermissionConstraint { get }
     

--- a/FlintCore/Constraints/Permissions/SystemPermissionConstraint.swift
+++ b/FlintCore/Constraints/Permissions/SystemPermissionConstraint.swift
@@ -9,14 +9,17 @@
 import Foundation
 
 /// Defines a system permission that conditional features can use as a constraint.
+///
+/// - note: Any associated values for permission variants must use Flint or foundation types because
+/// we cannot have permissions force dependency on any given framework.
 public enum SystemPermissionConstraint: Hashable, CustomStringConvertible {
     case camera
     case photos
     case location(usage: LocationUsage)
+    case contacts(entity: ContactsEntity)
 
 // The rest of these are "coming soon"
 /*
-    case contacts
     case calendars
     case reminders
     case homeKit
@@ -36,6 +39,10 @@ public enum SystemPermissionConstraint: Hashable, CustomStringConvertible {
                     case .whenInUse: return "Location when in use"
                     case .always: return "Location always"
                 }
+            case .contacts(let entity):
+                switch entity {
+                    case .contacts: return "Contacts"
+                }
         }
     }
 }
@@ -46,6 +53,7 @@ extension SystemPermissionConstraint: FeatureConstraint {
         switch self {
             case .camera: return ""
             case .location(let usage): return "usage \(usage)"
+            case .contacts(_): return ""
             case .photos: return ""
         }
     }

--- a/FlintUISandbox/AppDelegate.swift
+++ b/FlintUISandbox/AppDelegate.swift
@@ -63,6 +63,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
 
     var window: UIWindow?
     var testTimer: DispatchSourceTimer?
+    var controller: AuthorisationController?
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         Flint.quickSetup(FakeFeatures.self, domains: [], initialDebugLogLevel: .info, initialProductionLogLevel: .info)
@@ -98,6 +99,9 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
             }
             print("parametersDescription: \(result.constraint.parametersDescription)")
         }
+        
+        controller = FakeFeature.permissionAuthorisationController(using: nil)
+        controller?.begin(retryHandler: nil)
         return true
     }
 

--- a/FlintUISandbox/AppDelegate.swift
+++ b/FlintUISandbox/AppDelegate.swift
@@ -42,6 +42,7 @@ final class FakeFeature: ConditionalFeature {
         requirements.iOSOnly = 10
         requirements.permission(.camera)
         requirements.permission(.photos)
+        requirements.permission(.contacts(entity: .contacts))
     }
 }
 

--- a/FlintUISandbox/Info.plist
+++ b/FlintUISandbox/Info.plist
@@ -22,6 +22,8 @@
 	<true/>
 	<key>NSCameraUsageDescription</key>
 	<string>Testing camera permission</string>
+	<key>NSContactsUsageDescription</key>
+	<string>Contacts testing</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Photos testing</string>
 	<key>NSUserActivityTypes</key>

--- a/FlintUISandbox/Info.plist
+++ b/FlintUISandbox/Info.plist
@@ -20,6 +20,10 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
+	<key>NSCameraUsageDescription</key>
+	<string>Testing camera permission</string>
+	<key>NSPhotoLibraryUsageDescription</key>
+	<string>Photos testing</string>
 	<key>NSUserActivityTypes</key>
 	<array>
 		<string>co.montanafloss.FlintUISandbox.do-something-fake</string>


### PR DESCRIPTION
Turned out the build-time and runtime platform checks were onerous because you had to check them before creating the permission adapter. I've refactored that so permission adapters can encapsulate all of that themselves and simply indicate whether or not they are valid for the current platform.