### PR TITLE
Catch undeclared actions and help the use solve the problem

### DIFF
--- a/Flint.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
+++ b/Flint.xcworkspace/xcshareddata/WorkspaceSettings.xcsettings
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>BuildSystemType</key>
+	<string>Original</string>
+</dict>
+</plist>

--- a/FlintCore/Conditional Features/ConditionalFeature.swift
+++ b/FlintCore/Conditional Features/ConditionalFeature.swift
@@ -52,8 +52,11 @@ public extension ConditionalFeature {
     ///
     /// The default `isAvailable` implementation will delegate to the `AvailabilityChecker` to see if the feature is available.
     public static func request<T>(_ actionBinding: ConditionalActionBinding<Self, T>) -> ConditionalActionRequest<Self, T>? {
+        // Sanity checks and footgun avoidance
         Flint.requiresSetup()
         Flint.requiresPrepared(feature: actionBinding.feature)
+        precondition(Flint.isDeclared(actionBinding.action, on: actionBinding.feature) ,
+            "Action \(actionBinding.action) has not been declared on \(actionBinding.feature). Call 'declare' or 'publish' with it in your feature's prepare function.")
 
         /// The action is possible only if this feature is currently available
         guard let available = isAvailable, available == true else {

--- a/FlintCore/Conditional Features/ConditionalFeature.swift
+++ b/FlintCore/Conditional Features/ConditionalFeature.swift
@@ -55,8 +55,9 @@ public extension ConditionalFeature {
         // Sanity checks and footgun avoidance
         Flint.requiresSetup()
         Flint.requiresPrepared(feature: actionBinding.feature)
-        precondition(Flint.isDeclared(actionBinding.action, on: actionBinding.feature) ,
-            "Action \(actionBinding.action) has not been declared on \(actionBinding.feature). Call 'declare' or 'publish' with it in your feature's prepare function.")
+        guard Flint.isDeclared(actionBinding.action, on: actionBinding.feature) else {
+            fatalError("Action \(actionBinding.action) has not been declared on \(actionBinding.feature). Call 'declare' or 'publish' with it in your feature's prepare function.")
+        }
 
         /// The action is possible only if this feature is currently available
         guard let available = isAvailable, available == true else {

--- a/FlintCore/Constraints/Permissions/DefaultAuthorisationController.swift
+++ b/FlintCore/Constraints/Permissions/DefaultAuthorisationController.swift
@@ -33,6 +33,7 @@ class DefaultAuthorisationController: AuthorisationController {
         precondition(!cancelled, "Cannot use a cancelled authorisation controller")
         self.retryHandler = retryHandler
         if let coordinator = coordinator {
+            FlintInternal.logger?.debug("Authorisation controller notifying coordinator that it will begin")
             coordinator.willBeginPermissionAuthorisation(for: permissions) { permissionsToRequest in
                 if permissions.count > 0 {
                     sortedPermissionsToAuthorize = permissionsToRequest
@@ -52,16 +53,19 @@ class DefaultAuthorisationController: AuthorisationController {
     }
 
     func next() {
+        FlintInternal.logger?.debug("Authorisation controller checking next permission, remaining permissions: \(self.sortedPermissionsToAuthorize)")
         precondition(!cancelled, "Cannot use a cancelled authorisation controller")
         
         if sortedPermissionsToAuthorize.count > 0 {
             let permission = sortedPermissionsToAuthorize.removeFirst()
             
             func _requestPermission() {
+                FlintInternal.logger?.debug("Authorisation controller requesting permission: \(permission)")
                 Flint.permissionChecker.requestAuthorization(for: permission) { [weak self] permission, status in
                     guard let strongSelf = self else {
                         return
                     }
+                    FlintInternal.logger?.debug("Authorisation controller requested permission: \(permission), received status: \(status)")
                     if status != .authorized {
                         strongSelf.permissionsNotAuthorized.append(permission)
                     }

--- a/FlintCore/Constraints/Permissions/DefaultPermissionChecker.swift
+++ b/FlintCore/Constraints/Permissions/DefaultPermissionChecker.swift
@@ -105,7 +105,7 @@ public class DefaultPermissionChecker: SystemPermissionChecker, CustomDebugStrin
         FlintInternal.logger?.debug("Permission checker requesting authorization for: \(permission)")
 
         adapter.requestAuthorisation { adapter, status in
-            FlintInternal.logger?.debug("Permission checker authorization request for: \(permission) result in \(status)")
+            FlintInternal.logger?.debug("Permission checker authorization request for: \(permission) resulted in \(status)")
             completion(adapter.permission, status)
             // Tell our delegate that things were updated - caches will need to be invalidated etc.
             self.delegate?.permissionStatusDidChange(adapter.permission)

--- a/FlintCore/Constraints/Permissions/LocationPermissionAdapter.swift
+++ b/FlintCore/Constraints/Permissions/LocationPermissionAdapter.swift
@@ -80,9 +80,11 @@ import CoreLocation
         switch permission {
             case .location(usage: .always):
                 pendingCompletions.append(completion)
+                FlintInternal.logger?.debug("Location permission adapter requesting 'always' authorization")
                 locationManager.requestAlwaysAuthorization()
             case .location(usage: .whenInUse):
                 pendingCompletions.append(completion)
+                FlintInternal.logger?.debug("Location permission adapter requesting 'when in use' authorization")
                 locationManager.requestWhenInUseAuthorization()
             default:
                 fatalError("Incorrect permission type: \(permission)")
@@ -95,6 +97,7 @@ import CoreLocation
     // MARK: Location Manager delegate
 
     public func locationManager(_ manager: CLLocationManager, didChangeAuthorization status: CLAuthorizationStatus) {
+        FlintInternal.logger?.debug("Location permission adaoter received status change: \(status)")
         for completion in pendingCompletions {
             completion(self, authStatusToPermissionStatus(status))
         }

--- a/FlintCore/Core/ActionSession.swift
+++ b/FlintCore/Core/ActionSession.swift
@@ -311,8 +311,10 @@ public class ActionSession: CustomDebugStringConvertible {
             fatalError(message)
         }
 
+        // Sanity checkes and footgun avoidance
         Flint.requiresSetup()
         Flint.requiresPrepared(feature: request.actionBinding.feature)
+        precondition(Flint.isDeclared(request.actionBinding.action, on: request.actionBinding.feature) , "Action \(request.actionBinding.action) has not been declared on \(request.actionBinding.feature)")
         
         // Work out if we have a sequence for the request's feature, create a new one if not
         let actionStack = actionStackTracker.findOrCreateActionStack(for: request.actionBinding.feature,

--- a/FlintCore/Core/ActionSession.swift
+++ b/FlintCore/Core/ActionSession.swift
@@ -314,8 +314,9 @@ public class ActionSession: CustomDebugStringConvertible {
         // Sanity checks and footgun avoidance
         Flint.requiresSetup()
         Flint.requiresPrepared(feature: request.actionBinding.feature)
-        precondition(Flint.isDeclared(request.actionBinding.action, on: request.actionBinding.feature),
-            "Action \(request.actionBinding.action) has not been declared on \(request.actionBinding.feature). Call 'declare' or 'publish' with it in your feature's prepare function")
+        guard Flint.isDeclared(request.actionBinding.action, on: request.actionBinding.feature) else {
+            fatalError("Action \(request.actionBinding.action) has not been declared on \(request.actionBinding.feature). Call 'declare' or 'publish' with it in your feature's prepare function")
+        }
         
         // Work out if we have a sequence for the request's feature, create a new one if not
         let actionStack = actionStackTracker.findOrCreateActionStack(for: request.actionBinding.feature,

--- a/FlintCore/Core/ActionSession.swift
+++ b/FlintCore/Core/ActionSession.swift
@@ -311,10 +311,11 @@ public class ActionSession: CustomDebugStringConvertible {
             fatalError(message)
         }
 
-        // Sanity checkes and footgun avoidance
+        // Sanity checks and footgun avoidance
         Flint.requiresSetup()
         Flint.requiresPrepared(feature: request.actionBinding.feature)
-        precondition(Flint.isDeclared(request.actionBinding.action, on: request.actionBinding.feature) , "Action \(request.actionBinding.action) has not been declared on \(request.actionBinding.feature)")
+        precondition(Flint.isDeclared(request.actionBinding.action, on: request.actionBinding.feature),
+            "Action \(request.actionBinding.action) has not been declared on \(request.actionBinding.feature). Call 'declare' or 'publish' with it in your feature's prepare function")
         
         // Work out if we have a sequence for the request's feature, create a new one if not
         let actionStack = actionStackTracker.findOrCreateActionStack(for: request.actionBinding.feature,

--- a/FlintCore/Core/Flint.swift
+++ b/FlintCore/Core/Flint.swift
@@ -444,7 +444,7 @@ extension Flint {
     static func bind<T>(_ action: T.Type, to feature: FeatureDefinition.Type) where T: Action {
         FlintInternal.logger?.debug("Binding action \(action) to feature: \(self)")
 
-        // Get the existing FeatureMetadata for the feature, create if not found
+        // Get the existing FeatureMetadata for the feature
         metadataAccessQueue.sync {
             guard let featureMetadata = metadata(for: feature) else {
                 preconditionFailure("Cannot bind action \(action) to feature \(feature) because the feature has not been prepared")
@@ -458,12 +458,22 @@ extension Flint {
         FlintInternal.logger?.debug("Publishing binding of action \(action) to feature: \(self)")
 
         metadataAccessQueue.sync {
-            // Get the existing FeatureMetadata for the feature, create if not found
+            // Get the existing FeatureMetadata for the feature
             guard let featureMetadata = metadata(for: feature) else {
                 preconditionFailure("Cannot bind action \(action) to feature \(feature) because the feature has not been prepared")
             }
             
             featureMetadata.publish(action)
+        }
+    }
+    
+    static func isDeclared<T>(_ action: T.Type, on feature: FeatureDefinition.Type) -> Bool where T: Action {
+        return metadataAccessQueue.sync {
+            guard let featureMetadata = metadata(for: feature) else {
+                preconditionFailure("Cannot bind action \(action) to feature \(feature) because the feature has not been prepared")
+            }
+            
+            return featureMetadata.hasDeclaredAction(action)
         }
     }
     

--- a/FlintCore/Features/FeatureMetadata.swift
+++ b/FlintCore/Features/FeatureMetadata.swift
@@ -30,6 +30,10 @@ public class FeatureMetadata: Hashable, Equatable {
         _bind(action, publish: false)
     }
 
+    func hasDeclaredAction<T>(_ action: T.Type) -> Bool where T: Action {
+        return actions.contains { $0.typeName == String(reflecting: action) }
+    }
+
     func publish<T>(_ action: T.Type) where T: Action {
         _bind(action, publish: true)
     }

--- a/FlintUISandbox/AppDelegate.swift
+++ b/FlintUISandbox/AppDelegate.swift
@@ -35,7 +35,7 @@ final class FakeFeature: ConditionalFeature {
     static let action1 = action(DoSomethingFakeAction.self)
     
     static func prepare(actions: FeatureActionsBuilder) {
-        actions.declare(action1)
+//        actions.declare(action1)
     }
 
     static func constraints(requirements: FeatureConstraintsBuilder) {


### PR DESCRIPTION
Undeclared actions mean we don't have metadata for the actions, which defeats the feature browser and conditional availability etc.

Also some fly-by fixes to location permissions and the authorisation controller because bad things were happening. Core Location tell us auth status changed simply by us asking for it (at least in the simulator) so we protect against this false information now as it could screw up the state of the auth controller.