### PR TITLE
Fix requiredUserInfoKeys not including auto url

### DIFF
--- a/FlintCore/Activities/ActivityBuilder.swift
+++ b/FlintCore/Activities/ActivityBuilder.swift
@@ -185,6 +185,7 @@ public class ActivityBuilder<T> {
         } else if let url = appLink {
             // Put in the auto link, if set and part of a URLMapped feature
             activity.addUserInfoEntries(from: [ActivitiesFeature.autoURLUserInfoKey: url])
+            activity.requiredUserInfoKeys = [ActivitiesFeature.autoURLUserInfoKey]
             shouldWarnAutoContinueWillFail = false
         }
     


### PR DESCRIPTION
Siri ProActive wouldn’t work because there's no userInfo it knows it needs to persist/consider