### PR TITLE
Use dynamic linking on permissions APIs where needed

### DIFF
--- a/FlintCore.xcodeproj/project.pbxproj
+++ b/FlintCore.xcodeproj/project.pbxproj
@@ -218,6 +218,7 @@
 		49647D3B20384077005F9825 /* ActivitiesFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49647D3A20384077005F9825 /* ActivitiesFeature.swift */; };
 		49647D3D203873C7005F9825 /* FlintFeatures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49647D3C203873C7005F9825 /* FlintFeatures.swift */; };
 		49647D3F203B117D005F9825 /* URLMapped.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49647D3E203B117D005F9825 /* URLMapped.swift */; };
+		49653A3420F26DA400AFDDDB /* ContactsPermissionAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494C278A20BEF11900053FF7 /* ContactsPermissionAdapter.swift */; };
 		496E26ED203B7380008E4320 /* ContextualLoggerTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 496E26EC203B7380008E4320 /* ContextualLoggerTarget.swift */; };
 		496E26EF203B7506008E4320 /* FocusContextualLoggerTarget.swift in Sources */ = {isa = PBXBuildFile; fileRef = 496E26EE203B7506008E4320 /* FocusContextualLoggerTarget.swift */; };
 		496F8F10203EE9EA003AB29B /* FlintCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 496F8F07203EE9E9003AB29B /* FlintCore.framework */; };
@@ -2417,6 +2418,7 @@
 				49966D91200A63EB004C4AA0 /* UserFeatureToggles.swift in Sources */,
 				499FE33D20B9FE7A00552CE9 /* OSLogOutput.swift in Sources */,
 				496136C0209900CE00291885 /* SystemPermissionAdapter.swift in Sources */,
+				49653A3420F26DA400AFDDDB /* ContactsPermissionAdapter.swift in Sources */,
 				49819EB01FC9C1500013AF55 /* Action.swift in Sources */,
 				495B6C69202B60A50024CDFB /* FlintAppInfo.swift in Sources */,
 				4929823C205ED12C00267A49 /* ActionMetadata.swift in Sources */,

--- a/FlintCore.xcodeproj/project.pbxproj
+++ b/FlintCore.xcodeproj/project.pbxproj
@@ -97,11 +97,9 @@
 		4946FAC7208E23740097E10E /* ActionPerformOutcome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4946FAC4208E23740097E10E /* ActionPerformOutcome.swift */; };
 		4946FAC8208E23740097E10E /* ActionPerformOutcome.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4946FAC4208E23740097E10E /* ActionPerformOutcome.swift */; };
 		4948DBE6204D77A90030ED79 /* ActionContext.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4948DBE5204D77A90030ED79 /* ActionContext.swift */; };
-		494C278B20BEF11900053FF7 /* ContactsPermissionAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494C278A20BEF11900053FF7 /* ContactsPermissionAdapter.swift */; };
 		494C278C20BEF11900053FF7 /* ContactsPermissionAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494C278A20BEF11900053FF7 /* ContactsPermissionAdapter.swift */; };
 		494C278D20BEF11900053FF7 /* ContactsPermissionAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494C278A20BEF11900053FF7 /* ContactsPermissionAdapter.swift */; };
 		494C278E20BEF11900053FF7 /* ContactsPermissionAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494C278A20BEF11900053FF7 /* ContactsPermissionAdapter.swift */; };
-		494C279020BF374F00053FF7 /* EventKitPermissionAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494C278F20BF374F00053FF7 /* EventKitPermissionAdapter.swift */; };
 		494C279120BF374F00053FF7 /* EventKitPermissionAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494C278F20BF374F00053FF7 /* EventKitPermissionAdapter.swift */; };
 		494C279220BF374F00053FF7 /* EventKitPermissionAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494C278F20BF374F00053FF7 /* EventKitPermissionAdapter.swift */; };
 		494C279320BF374F00053FF7 /* EventKitPermissionAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494C278F20BF374F00053FF7 /* EventKitPermissionAdapter.swift */; };
@@ -215,7 +213,6 @@
 		496136E320990F5C00291885 /* MockFeatureConstraintsEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 496136E220990F5C00291885 /* MockFeatureConstraintsEvaluator.swift */; };
 		496136E420990F5C00291885 /* MockFeatureConstraintsEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 496136E220990F5C00291885 /* MockFeatureConstraintsEvaluator.swift */; };
 		496136E520990F5C00291885 /* MockFeatureConstraintsEvaluator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 496136E220990F5C00291885 /* MockFeatureConstraintsEvaluator.swift */; };
-		496267B41F8BC14D002C83F2 /* README.md in Resources */ = {isa = PBXBuildFile; fileRef = 496267B31F8BC14D002C83F2 /* README.md */; };
 		49647D372037434B005F9825 /* StoreKitPurchaseTracker.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49647D362037434B005F9825 /* StoreKitPurchaseTracker.swift */; };
 		49647D3920374DE1005F9825 /* ActionStackEntry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49647D3820374DE1005F9825 /* ActionStackEntry.swift */; };
 		49647D3B20384077005F9825 /* ActivitiesFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49647D3A20384077005F9825 /* ActivitiesFeature.swift */; };
@@ -439,6 +436,7 @@
 		49839CED2046D1D500C0AED3 /* DebugReporting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49839CEC2046D1D500C0AED3 /* DebugReporting.swift */; };
 		49839CEE2046D1D500C0AED3 /* DebugReporting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49839CEC2046D1D500C0AED3 /* DebugReporting.swift */; };
 		49839CEF2046D1D500C0AED3 /* DebugReporting.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49839CEC2046D1D500C0AED3 /* DebugReporting.swift */; };
+		49846EFA20F233860094060C /* EventKitPermissionAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 494C278F20BF374F00053FF7 /* EventKitPermissionAdapter.swift */; };
 		49891EB22094BEB600B9BCBF /* PurchaseTrackerObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49891EB12094BEB600B9BCBF /* PurchaseTrackerObserver.swift */; };
 		49891EB32094BEB600B9BCBF /* PurchaseTrackerObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49891EB12094BEB600B9BCBF /* PurchaseTrackerObserver.swift */; };
 		49891EB42094BEB600B9BCBF /* PurchaseTrackerObserver.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49891EB12094BEB600B9BCBF /* PurchaseTrackerObserver.swift */; };
@@ -1753,7 +1751,6 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				496267B41F8BC14D002C83F2 /* README.md in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2331,11 +2328,9 @@
 				49DB926020757D9500F758DC /* AnalyticsProvider.swift in Sources */,
 				49CCF0CD1F8BB24000F7020E /* ActionSession.swift in Sources */,
 				49935BCC206B901800CB2B5D /* ConditionalActionRequest.swift in Sources */,
-				494C279020BF374F00053FF7 /* EventKitPermissionAdapter.swift in Sources */,
 				49A999FC1FF7FC5200A64E8C /* ConsoleAnalyticsProvider.swift in Sources */,
 				496136CF2099013000291885 /* PhotosPermissionAdapter.swift in Sources */,
 				49298241205FCC6000267A49 /* ActionOutcome.swift in Sources */,
-				494C278B20BEF11900053FF7 /* ContactsPermissionAdapter.swift in Sources */,
 				494F593D2098ABB20075E7EE /* UserTogglePreconditionEvaluator.swift in Sources */,
 				49935BCA206AA80A00CB2B5D /* LogEvent.swift in Sources */,
 				4927FEF8208A537100163576 /* PublishCurrentActionActivityAction.swift in Sources */,
@@ -2356,6 +2351,7 @@
 				494C27A320C01CE400053FF7 /* MotionPermissionAdapter.swift in Sources */,
 				49298237205ED11900267A49 /* FeatureMetadata.swift in Sources */,
 				496136D92099017400291885 /* DefaultPermissionChecker.swift in Sources */,
+				49846EFA20F233860094060C /* EventKitPermissionAdapter.swift in Sources */,
 				49647D3D203873C7005F9825 /* FlintFeatures.swift in Sources */,
 				49DFB7CF20A2DFD500D3AE68 /* PermissionAuthorisationCoordinator.swift in Sources */,
 				49F37A46209B2C1E00B27671 /* FeatureConstraintsEvaluation.swift in Sources */,

--- a/FlintCore.xcodeproj/project.pbxproj
+++ b/FlintCore.xcodeproj/project.pbxproj
@@ -403,6 +403,10 @@
 		496F8FFE203EEBDB003AB29B /* StaticActionBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49819EB91FC9C2310013AF55 /* StaticActionBinding.swift */; };
 		496F8FFF203EEBDB003AB29B /* TopicPath+Extensions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49C9C3791FFD317800E4D500 /* TopicPath+Extensions.swift */; };
 		496F9000203EEBDB003AB29B /* FlintInternal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49E1A230203C31C900F7555C /* FlintInternal.swift */; };
+		497175FE20ECE00A00F88482 /* DynamicLibraryBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 497175FD20ECE00A00F88482 /* DynamicLibraryBinding.swift */; };
+		497175FF20ECE00A00F88482 /* DynamicLibraryBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 497175FD20ECE00A00F88482 /* DynamicLibraryBinding.swift */; };
+		4971760020ECE00A00F88482 /* DynamicLibraryBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 497175FD20ECE00A00F88482 /* DynamicLibraryBinding.swift */; };
+		4971760120ECE00A00F88482 /* DynamicLibraryBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 497175FD20ECE00A00F88482 /* DynamicLibraryBinding.swift */; };
 		4976923B201F3CBE00F97BD5 /* URLMappingsBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4976923A201F3CBE00F97BD5 /* URLMappingsBuilder.swift */; };
 		4976923D201F3CEE00F97BD5 /* ActionURLMappings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4976923C201F3CEE00F97BD5 /* ActionURLMappings.swift */; };
 		4976923F201F3D5A00F97BD5 /* URLMappings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4976923E201F3D5A00F97BD5 /* URLMappings.swift */; };
@@ -809,6 +813,7 @@
 		496F8F3F203EEA23003AB29B /* FlintCore.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = FlintCore.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		496F8F41203EEA23003AB29B /* FlintCore_watchOS.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = FlintCore_watchOS.h; sourceTree = "<group>"; };
 		496F8F42203EEA23003AB29B /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		497175FD20ECE00A00F88482 /* DynamicLibraryBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DynamicLibraryBinding.swift; sourceTree = "<group>"; };
 		4976923A201F3CBE00F97BD5 /* URLMappingsBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLMappingsBuilder.swift; sourceTree = "<group>"; };
 		4976923C201F3CEE00F97BD5 /* ActionURLMappings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionURLMappings.swift; sourceTree = "<group>"; };
 		4976923E201F3D5A00F97BD5 /* URLMappings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLMappings.swift; sourceTree = "<group>"; };
@@ -1249,6 +1254,7 @@
 			isa = PBXGroup;
 			children = (
 				4914EFC62067C4D000FE0F41 /* Formatters.swift */,
+				497175FD20ECE00A00F88482 /* DynamicLibraryBinding.swift */,
 				498B80852001210300E44C91 /* String+Extensions.swift */,
 				495FD9FB20026A520007A427 /* ObserverSet.swift */,
 				49935BE9206D23E400CB2B5D /* LIFOArrayQueue.swift */,
@@ -1783,6 +1789,7 @@
 				496F8FCC203EEBDA003AB29B /* FeatureGroup.swift in Sources */,
 				49935BD2206BA0DF00CB2B5D /* LogEventContext.swift in Sources */,
 				49DFB7D020A2DFD500D3AE68 /* PermissionAuthorisationCoordinator.swift in Sources */,
+				497175FF20ECE00A00F88482 /* DynamicLibraryBinding.swift in Sources */,
 				496F8FC2203EEBDA003AB29B /* ActionDispatcher.swift in Sources */,
 				49298242205FCC6000267A49 /* ActionOutcome.swift in Sources */,
 				494F59432098ABC30075E7EE /* ConstraintsEvaluator.swift in Sources */,
@@ -1958,6 +1965,7 @@
 				496F8FE1203EEBDA003AB29B /* FeatureGroup.swift in Sources */,
 				49935BD3206BA0DF00CB2B5D /* LogEventContext.swift in Sources */,
 				49DFB7D120A2DFD500D3AE68 /* PermissionAuthorisationCoordinator.swift in Sources */,
+				4971760020ECE00A00F88482 /* DynamicLibraryBinding.swift in Sources */,
 				496F8FD7203EEBDA003AB29B /* ActionDispatcher.swift in Sources */,
 				49298243205FCC6000267A49 /* ActionOutcome.swift in Sources */,
 				494F59442098ABC30075E7EE /* ConstraintsEvaluator.swift in Sources */,
@@ -2133,6 +2141,7 @@
 				49BC1C5A20867C2400A7FC77 /* ActionStack.swift in Sources */,
 				496F8FFC203EEBDB003AB29B /* NoPresenter.swift in Sources */,
 				4929823A205ED11900267A49 /* FeatureMetadata.swift in Sources */,
+				4971760120ECE00A00F88482 /* DynamicLibraryBinding.swift in Sources */,
 				49DB92462073C67900F758DC /* PurchaseRequirement.swift in Sources */,
 				49935BED206D23E400CB2B5D /* LIFOArrayQueue.swift in Sources */,
 				496F8FF6203EEBDB003AB29B /* FeatureGroup.swift in Sources */,
@@ -2301,6 +2310,7 @@
 				49D447F71FEC6AA800DBB352 /* ConditionalFeature.swift in Sources */,
 				496E26EF203B7506008E4320 /* FocusContextualLoggerTarget.swift in Sources */,
 				495FD9FA20026A180007A427 /* Timeline.swift in Sources */,
+				497175FE20ECE00A00F88482 /* DynamicLibraryBinding.swift in Sources */,
 				496E26ED203B7380008E4320 /* ContextualLoggerTarget.swift in Sources */,
 				4956D5D420986BDE002A2A35 /* FeatureConstraintsBuilder.swift in Sources */,
 				494F591F2098AA5D0075E7EE /* DeclaredFeatureConstraints.swift in Sources */,

--- a/FlintCore.xcodeproj/project.pbxproj
+++ b/FlintCore.xcodeproj/project.pbxproj
@@ -617,10 +617,10 @@
 		49EA0BCF208B874900B9A32E /* SmartDispatchQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49EA0BCD208B874900B9A32E /* SmartDispatchQueue.swift */; };
 		49EA0BD0208B874900B9A32E /* SmartDispatchQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49EA0BCD208B874900B9A32E /* SmartDispatchQueue.swift */; };
 		49EA0BD1208B874900B9A32E /* SmartDispatchQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49EA0BCD208B874900B9A32E /* SmartDispatchQueue.swift */; };
-		49EFE2BC20C3F4DA00063E5F /* SpeechRecognitionPermissionAdapt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49EFE2BB20C3F4DA00063E5F /* SpeechRecognitionPermissionAdapt.swift */; };
-		49EFE2BD20C3F4DA00063E5F /* SpeechRecognitionPermissionAdapt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49EFE2BB20C3F4DA00063E5F /* SpeechRecognitionPermissionAdapt.swift */; };
-		49EFE2BE20C3F4DA00063E5F /* SpeechRecognitionPermissionAdapt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49EFE2BB20C3F4DA00063E5F /* SpeechRecognitionPermissionAdapt.swift */; };
-		49EFE2BF20C3F4DA00063E5F /* SpeechRecognitionPermissionAdapt.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49EFE2BB20C3F4DA00063E5F /* SpeechRecognitionPermissionAdapt.swift */; };
+		49EFE2BC20C3F4DA00063E5F /* SpeechRecognitionPermissionAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49EFE2BB20C3F4DA00063E5F /* SpeechRecognitionPermissionAdapter.swift */; };
+		49EFE2BD20C3F4DA00063E5F /* SpeechRecognitionPermissionAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49EFE2BB20C3F4DA00063E5F /* SpeechRecognitionPermissionAdapter.swift */; };
+		49EFE2BE20C3F4DA00063E5F /* SpeechRecognitionPermissionAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49EFE2BB20C3F4DA00063E5F /* SpeechRecognitionPermissionAdapter.swift */; };
+		49EFE2BF20C3F4DA00063E5F /* SpeechRecognitionPermissionAdapter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49EFE2BB20C3F4DA00063E5F /* SpeechRecognitionPermissionAdapter.swift */; };
 		49F2CF221FF7B56B004F16EF /* NoPresenter.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F2CF211FF7B56B004F16EF /* NoPresenter.swift */; };
 		49F2CF241FF7EB2C004F16EF /* ConditionalActionBinding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F2CF231FF7EB2C004F16EF /* ConditionalActionBinding.swift */; };
 		49F2CF261FF7EB78004F16EF /* NoInput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F2CF251FF7EB78004F16EF /* NoInput.swift */; };
@@ -914,7 +914,7 @@
 		49E1A230203C31C900F7555C /* FlintInternal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlintInternal.swift; sourceTree = "<group>"; };
 		49E1A232203C35C800F7555C /* RouteScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteScope.swift; sourceTree = "<group>"; };
 		49EA0BCD208B874900B9A32E /* SmartDispatchQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartDispatchQueue.swift; sourceTree = "<group>"; };
-		49EFE2BB20C3F4DA00063E5F /* SpeechRecognitionPermissionAdapt.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechRecognitionPermissionAdapt.swift; sourceTree = "<group>"; };
+		49EFE2BB20C3F4DA00063E5F /* SpeechRecognitionPermissionAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechRecognitionPermissionAdapter.swift; sourceTree = "<group>"; };
 		49F2CF211FF7B56B004F16EF /* NoPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoPresenter.swift; sourceTree = "<group>"; };
 		49F2CF231FF7EB2C004F16EF /* ConditionalActionBinding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConditionalActionBinding.swift; sourceTree = "<group>"; };
 		49F2CF251FF7EB78004F16EF /* NoInput.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoInput.swift; sourceTree = "<group>"; };
@@ -1053,6 +1053,8 @@
 				496136D32099015900291885 /* LocationPermissionAdapter.swift */,
 				494C278A20BEF11900053FF7 /* ContactsPermissionAdapter.swift */,
 				494C278F20BF374F00053FF7 /* EventKitPermissionAdapter.swift */,
+				494C27A220C01CE400053FF7 /* MotionPermissionAdapter.swift */,
+				49EFE2BB20C3F4DA00063E5F /* SpeechRecognitionPermissionAdapter.swift */,
 				496136D82099017400291885 /* DefaultPermissionChecker.swift */,
 				496136DD2099028F00291885 /* LocationUsage.swift */,
 				49DFB7C420A2DF8500D3AE68 /* AuthorisationController.swift */,
@@ -1060,8 +1062,6 @@
 				49DFB7CE20A2DFD500D3AE68 /* PermissionAuthorisationCoordinator.swift */,
 				49DFB7D320A2E00500D3AE68 /* SystemPermissionRequestAction.swift */,
 				49DFB7DD20A3464800D3AE68 /* FeaturePermissionRequirements.swift */,
-				494C27A220C01CE400053FF7 /* MotionPermissionAdapter.swift */,
-				49EFE2BB20C3F4DA00063E5F /* SpeechRecognitionPermissionAdapt.swift */,
 			);
 			path = Permissions;
 			sourceTree = "<group>";
@@ -1858,7 +1858,7 @@
 				496F8FAC203EEBD3003AB29B /* RouteParametersCodable.swift in Sources */,
 				4927FF01208A542700163576 /* PublishActivityRequest.swift in Sources */,
 				496F8F47203EEB0D003AB29B /* String+Extensions.swift in Sources */,
-				49EFE2BD20C3F4DA00063E5F /* SpeechRecognitionPermissionAdapt.swift in Sources */,
+				49EFE2BD20C3F4DA00063E5F /* SpeechRecognitionPermissionAdapter.swift in Sources */,
 				496F8F58203EEBB1003AB29B /* ContextualLoggerFactory.swift in Sources */,
 				49839CEA2046D1CA00C0AED3 /* DebugReportable.swift in Sources */,
 				496F8FC9203EEBDA003AB29B /* FeatureDefinition.swift in Sources */,
@@ -2034,7 +2034,7 @@
 				496F8FB4203EEBD4003AB29B /* RouteParametersCodable.swift in Sources */,
 				4927FF02208A542700163576 /* PublishActivityRequest.swift in Sources */,
 				496F8F48203EEB0E003AB29B /* String+Extensions.swift in Sources */,
-				49EFE2BE20C3F4DA00063E5F /* SpeechRecognitionPermissionAdapt.swift in Sources */,
+				49EFE2BE20C3F4DA00063E5F /* SpeechRecognitionPermissionAdapter.swift in Sources */,
 				496F8F67203EEBB2003AB29B /* ContextualLoggerFactory.swift in Sources */,
 				49839CEB2046D1CA00C0AED3 /* DebugReportable.swift in Sources */,
 				496F8FDE203EEBDA003AB29B /* FeatureDefinition.swift in Sources */,
@@ -2210,7 +2210,7 @@
 				49FC460C20A4795F00679F97 /* PerformIncomingURLAction.swift in Sources */,
 				49FC460620A4792700679F97 /* Formatters.swift in Sources */,
 				494F59132098AA140075E7EE /* OperatingSystemVersion+Utilities.swift in Sources */,
-				49EFE2BF20C3F4DA00063E5F /* SpeechRecognitionPermissionAdapt.swift in Sources */,
+				49EFE2BF20C3F4DA00063E5F /* SpeechRecognitionPermissionAdapter.swift in Sources */,
 				496F8FBF203EEBD4003AB29B /* URLMappings.swift in Sources */,
 				496F8F92203EEBBC003AB29B /* ConditionalFeatureDefinition.swift in Sources */,
 				496F8F51203EEBA8003AB29B /* AnalyticsReporting.swift in Sources */,
@@ -2379,7 +2379,7 @@
 				49A99A061FF9072200A64E8C /* PrintLoggerOutput.swift in Sources */,
 				498AF6E1202729AE00AFE666 /* URLMapping.swift in Sources */,
 				49819EBC1FC9C3660013AF55 /* ActionRequest.swift in Sources */,
-				49EFE2BC20C3F4DA00063E5F /* SpeechRecognitionPermissionAdapt.swift in Sources */,
+				49EFE2BC20C3F4DA00063E5F /* SpeechRecognitionPermissionAdapter.swift in Sources */,
 				49839CE92046D1CA00C0AED3 /* DebugReportable.swift in Sources */,
 				49DFB7D920A3462600D3AE68 /* FeaturePurchaseRequirements.swift in Sources */,
 				49891EB22094BEB600B9BCBF /* PurchaseTrackerObserver.swift in Sources */,
@@ -2830,6 +2830,7 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_MODULES_AUTOLINK = NO;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;
@@ -2892,6 +2893,7 @@
 				CLANG_CXX_LIBRARY = "libc++";
 				CLANG_ENABLE_MODULES = YES;
 				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_MODULES_AUTOLINK = NO;
 				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
 				CLANG_WARN_BOOL_CONVERSION = YES;
 				CLANG_WARN_COMMA = YES;

--- a/FlintCore/Constraints/Permissions/CameraPermissionAdapter.swift
+++ b/FlintCore/Constraints/Permissions/CameraPermissionAdapter.swift
@@ -11,7 +11,6 @@ import AVFoundation
 
 @objc protocol ProxyCaptureDevice {
     // We don't mark these static as we call them on the class itself.
-    
     @objc(authorizationStatusForMediaType:)
     func authorizationStatus(for mediaType: AVMediaType) -> AVAuthorizationStatus
     @objc(requestAccessForMediaType:completionHandler:)

--- a/FlintCore/Constraints/Permissions/CameraPermissionAdapter.swift
+++ b/FlintCore/Constraints/Permissions/CameraPermissionAdapter.swift
@@ -9,6 +9,7 @@
 import Foundation
 import AVFoundation
 
+#if os(iOS) || os(macOS)
 @objc enum ProxyAVAuthorizationStatus: Int {
     case notDetermined
     case restricted
@@ -24,6 +25,7 @@ import AVFoundation
     func requestAccess(for mediaType: AVMediaType, completionHandler handler: @escaping (Bool) -> Void)
 
 }
+#endif
 
 /// Checks and authorises access to the Camera on supported platforms
 ///
@@ -45,9 +47,10 @@ class CameraPermissionAdapter: SystemPermissionAdapter {
     let permission: SystemPermissionConstraint
     let usageDescriptionKey: String = "NSCameraUsageDescription"
 
+#if os(iOS) || os(macOS)
     lazy var captureDeviceClass: AnyObject = { NSClassFromString("AVCaptureDevice")! }()
     lazy var proxyCaptureDeviceClass: ProxyCaptureDevice = { unsafeBitCast(self.captureDeviceClass, to: ProxyCaptureDevice.self) }()
-    
+#endif
     var status: SystemPermissionStatus {
 #if os(iOS)
         switch proxyCaptureDeviceClass.authorizationStatus(for: .video) {

--- a/FlintCore/Constraints/Permissions/CameraPermissionAdapter.swift
+++ b/FlintCore/Constraints/Permissions/CameraPermissionAdapter.swift
@@ -9,10 +9,17 @@
 import Foundation
 import AVFoundation
 
+@objc enum ProxyAVAuthorizationStatus: Int {
+    case notDetermined
+    case restricted
+    case denied
+    case authorized
+}
+
 @objc protocol ProxyCaptureDevice {
     // We don't mark these static as we call them on the class itself.
     @objc(authorizationStatusForMediaType:)
-    func authorizationStatus(for mediaType: AVMediaType) -> AVAuthorizationStatus
+    func authorizationStatus(for mediaType: AVMediaType) -> ProxyAVAuthorizationStatus
     @objc(requestAccessForMediaType:completionHandler:)
     func requestAccess(for mediaType: AVMediaType, completionHandler handler: @escaping (Bool) -> Void)
 

--- a/FlintCore/Constraints/Permissions/ContactsPermissionAdapter.swift
+++ b/FlintCore/Constraints/Permissions/ContactsPermissionAdapter.swift
@@ -27,7 +27,7 @@ public enum ContactsEntity {
     @objc(authorizationStatusForEntityType:)
     static func authorizationStatus(for entityType: ProxyEntityType) -> ProxyAuthorizationStatus
     @objc(requestAccessForEntityType:completionHandler:)
-    func requestAccess(for entityType: ProxyEntityType, completionHandler: @escaping (Bool, Error?) -> Swift.Void)
+    func requestAccess(for entityType: ProxyEntityType, completionHandler: @escaping (Bool, Error?) -> Void)
 }
 
 /// Checks and authorises access to the Contacts on supported platforms
@@ -53,13 +53,13 @@ class ContactsPermissionAdapter: SystemPermissionAdapter {
     }
 
     let permission: SystemPermissionConstraint
-    let usageDescriptionKey: String = "NSContactsUsageDescription"
+    let usageDescriptionKey: String = "NSContactsXXXXUsageDescription"
 
     typealias AuthorizationStatusFunc = (_ entityType: Int) -> Int
     typealias RequestAccessFunc = (_ entityType: Int, _ completion: (_ granted: Bool, _ error: Error?) -> Void) -> Void
 
     private let entityType: ProxyEntityType
-    private lazy var contactStore: AnyObject? = { try? instantiate(classNamed: "CNXXContactStore") }()
+    private lazy var contactStore: AnyObject? = { try? instantiate(classNamed: "CXXXNXXContactStore") }()
     private lazy var proxyContactStore: ProxyContactStore? = {
         guard let contactStore = contactStore else {
             return nil

--- a/FlintCore/Constraints/Permissions/ContactsPermissionAdapter.swift
+++ b/FlintCore/Constraints/Permissions/ContactsPermissionAdapter.swift
@@ -38,7 +38,7 @@ class ContactsPermissionAdapter: SystemPermissionAdapter {
 #if !os(tvOS)
         if #available(iOS 9, macOS 10.11, watchOS 2, *) {
             // Do this in case it is not auto-linked on all supported platforms
-            let isLinked = libraryIsLinkedForClass("CNXXContactStore")
+            let isLinked = libraryIsLinkedForClass("CNContactStore")
             return isLinked
         } else {
             return false
@@ -53,13 +53,13 @@ class ContactsPermissionAdapter: SystemPermissionAdapter {
     }
 
     let permission: SystemPermissionConstraint
-    let usageDescriptionKey: String = "NSContactsXXXXUsageDescription"
+    let usageDescriptionKey: String = "NSContactsUsageDescription"
 
     typealias AuthorizationStatusFunc = (_ entityType: Int) -> Int
     typealias RequestAccessFunc = (_ entityType: Int, _ completion: (_ granted: Bool, _ error: Error?) -> Void) -> Void
 
     private let entityType: ProxyEntityType
-    private lazy var contactStore: AnyObject? = { try? instantiate(classNamed: "CXXXNXXContactStore") }()
+    private lazy var contactStore: AnyObject? = { try? instantiate(classNamed: "CNContactStore") }()
     private lazy var proxyContactStore: ProxyContactStore? = {
         guard let contactStore = contactStore else {
             return nil

--- a/FlintCore/Constraints/Permissions/ContactsPermissionAdapter.swift
+++ b/FlintCore/Constraints/Permissions/ContactsPermissionAdapter.swift
@@ -30,7 +30,7 @@ class ContactsPermissionAdapter: SystemPermissionAdapter {
 #if !os(tvOS)
         if #available(iOS 9, macOS 10.11, watchOS 2, *) {
             // Do this in case it is not auto-linked on all supported platforms
-            let isLinked = libraryIsLinkedForClass("CNContactStore")
+            let isLinked = libraryIsLinkedForClass("XXXContactStore")
             return isLinked
         } else {
             return false
@@ -52,7 +52,7 @@ class ContactsPermissionAdapter: SystemPermissionAdapter {
     typealias RequestAccessFunc = (_ entityType: Int, _ completion: (_ granted: Bool, _ error: Error?) -> Void) -> Void
 
     let entityType: CNEntityType
-    lazy var contactStore: AnyObject = { try! instantiate(classNamed: "CNContactStore") }()
+    lazy var contactStore: AnyObject = { try! instantiate(classNamed: "XXXContactStore") }()
     lazy var proxyContactStore: ProxyContactStore = { unsafeBitCast(self.contactStore, to: ProxyContactStore.self) }()
 #endif
 

--- a/FlintCore/Constraints/Permissions/ContactsPermissionAdapter.swift
+++ b/FlintCore/Constraints/Permissions/ContactsPermissionAdapter.swift
@@ -38,7 +38,7 @@ class ContactsPermissionAdapter: SystemPermissionAdapter {
 #if !os(tvOS)
         if #available(iOS 9, macOS 10.11, watchOS 2, *) {
             // Do this in case it is not auto-linked on all supported platforms
-            let isLinked = libraryIsLinkedForClass("CNContactStore")
+            let isLinked = libraryIsLinkedForClass("CNXXContactStore")
             return isLinked
         } else {
             return false
@@ -59,7 +59,7 @@ class ContactsPermissionAdapter: SystemPermissionAdapter {
     typealias RequestAccessFunc = (_ entityType: Int, _ completion: (_ granted: Bool, _ error: Error?) -> Void) -> Void
 
     private let entityType: ProxyEntityType
-    private lazy var contactStore: AnyObject? = { try? instantiate(classNamed: "CNContactStore") }()
+    private lazy var contactStore: AnyObject? = { try? instantiate(classNamed: "CNXXContactStore") }()
     private lazy var proxyContactStore: ProxyContactStore? = {
         guard let contactStore = contactStore else {
             return nil

--- a/FlintCore/Constraints/Permissions/ContactsPermissionAdapter.swift
+++ b/FlintCore/Constraints/Permissions/ContactsPermissionAdapter.swift
@@ -30,7 +30,7 @@ class ContactsPermissionAdapter: SystemPermissionAdapter {
 #if !os(tvOS)
         if #available(iOS 9, macOS 10.11, watchOS 2, *) {
             // Do this in case it is not auto-linked on all supported platforms
-            let isLinked = libraryIsLinkedForClass("XXXContactStore")
+            let isLinked = libraryIsLinkedForClass("CNContactStore")
             return isLinked
         } else {
             return false
@@ -52,7 +52,7 @@ class ContactsPermissionAdapter: SystemPermissionAdapter {
     typealias RequestAccessFunc = (_ entityType: Int, _ completion: (_ granted: Bool, _ error: Error?) -> Void) -> Void
 
     let entityType: CNEntityType
-    lazy var contactStore: AnyObject = { try! instantiate(classNamed: "XXXContactStore") }()
+    lazy var contactStore: AnyObject = { try! instantiate(classNamed: "CNContactStore") }()
     lazy var proxyContactStore: ProxyContactStore = { unsafeBitCast(self.contactStore, to: ProxyContactStore.self) }()
 #endif
 

--- a/FlintCore/Constraints/Permissions/ContactsPermissionAdapter.swift
+++ b/FlintCore/Constraints/Permissions/ContactsPermissionAdapter.swift
@@ -38,7 +38,7 @@ class ContactsPermissionAdapter: SystemPermissionAdapter {
 #if !os(tvOS)
         if #available(iOS 9, macOS 10.11, watchOS 2, *) {
             // Do this in case it is not auto-linked on all supported platforms
-            let isLinked = libraryIsLinkedForClass("CNContactStore")
+            let isLinked = libraryIsLinkedForClass("CNxxxxContactStore")
             return isLinked
         } else {
             return false
@@ -53,13 +53,13 @@ class ContactsPermissionAdapter: SystemPermissionAdapter {
     }
 
     let permission: SystemPermissionConstraint
-    let usageDescriptionKey: String = "NSContactsUsageDescription"
+    let usageDescriptionKey: String = "NSxxxContactsUsageDescription"
 
     typealias AuthorizationStatusFunc = (_ entityType: Int) -> Int
     typealias RequestAccessFunc = (_ entityType: Int, _ completion: (_ granted: Bool, _ error: Error?) -> Void) -> Void
 
     private let entityType: ProxyEntityType
-    private lazy var contactStore: AnyObject? = { try? instantiate(classNamed: "CNContactStore") }()
+    private lazy var contactStore: AnyObject? = { try? instantiate(classNamed: "CNxxxxxContactStore") }()
     private lazy var proxyContactStore: ProxyContactStore? = {
         guard let contactStore = contactStore else {
             return nil

--- a/FlintCore/Constraints/Permissions/ContactsPermissionAdapter.swift
+++ b/FlintCore/Constraints/Permissions/ContactsPermissionAdapter.swift
@@ -60,7 +60,6 @@ class ContactsPermissionAdapter: SystemPermissionAdapter {
         }
     }()
 
-
     var status: SystemPermissionStatus {
         // Verify this first, we can't check availability at compile as it adds a libswiftContacts.dylib dependency
         guard let getAuthorizationStatus = getAuthorizationStatus else {

--- a/FlintCore/Constraints/Permissions/ContactsPermissionAdapter.swift
+++ b/FlintCore/Constraints/Permissions/ContactsPermissionAdapter.swift
@@ -39,13 +39,12 @@ class ContactsPermissionAdapter: SystemPermissionAdapter {
     let permission: SystemPermissionConstraint
     let usageDescriptionKey: String = "NSContactsUsageDescription"
 
+#if canImport(Contacts)
     typealias AuthorizationStatusFunc = (_ entityType: Int) -> Int
     typealias RequestAccessFunc = (_ entityType: Int, _ completion: (_ granted: Bool, _ error: Error?) -> Void) -> Void
 
-#if canImport(Contacts)
-    lazy var contactStore: AnyObject = { try! instantiate(classNamed: "CNContactStore") }()
     let entityType: CNEntityType
-
+    lazy var contactStore: AnyObject = { try! instantiate(classNamed: "CNContactStore") }()
     let getAuthorizationStatus: AuthorizationStatusFunc!
     lazy var requestAccess: RequestAccessFunc! = { try! dynamicBindIntAndBoolErrorOptionalClosureReturnVoid(toInstanceMethod: "requestAccessForEntityType:completionHandler:", on: contactStore) }()
 #endif

--- a/FlintCore/Constraints/Permissions/DefaultPermissionChecker.swift
+++ b/FlintCore/Constraints/Permissions/DefaultPermissionChecker.swift
@@ -67,6 +67,8 @@ public class DefaultPermissionChecker: SystemPermissionChecker, CustomDebugStrin
                 if adapter.isSupported {
                     // We probably need to also verify there is actual camera hardware, e.g. WatchOS
                     add(adapter.createAdapters(for: permission))
+                } else {
+                    FlintInternal.logger?.warning("Permission \(permission) is not supported. Either the target platform does not implement it, or your target is not linking the framework required.")
                 }
             }
 
@@ -90,7 +92,7 @@ public class DefaultPermissionChecker: SystemPermissionChecker, CustomDebugStrin
     
     public func status(of permission: SystemPermissionConstraint) -> SystemPermissionStatus {
         guard let adapter = getAdapter(for: permission) else {
-            FlintInternal.logger?.warning("Cannot get status \(permission), there is no permission adapter for it")
+            FlintInternal.logger?.warning("Cannot get status for permission \(permission), there is no adapter for it")
             return .unsupported
         }
         return adapter.status

--- a/FlintCore/Constraints/Permissions/DefaultPermissionChecker.swift
+++ b/FlintCore/Constraints/Permissions/DefaultPermissionChecker.swift
@@ -49,8 +49,8 @@ public class DefaultPermissionChecker: SystemPermissionChecker, CustomDebugStrin
                     adapterType = CameraPermissionAdapter.self
                 case .location:
                     adapterType = LocationPermissionAdapter.self
-                case .contacts:
-                    adapterType = ContactsPermissionAdapter.self
+//                case .contacts:
+//                    adapterType = ContactsPermissionAdapter.self
                 case .photos:
                     adapterType = PhotosPermissionAdapter.self
                 case .calendarEvents:

--- a/FlintCore/Constraints/Permissions/DefaultPermissionChecker.swift
+++ b/FlintCore/Constraints/Permissions/DefaultPermissionChecker.swift
@@ -49,8 +49,8 @@ public class DefaultPermissionChecker: SystemPermissionChecker, CustomDebugStrin
                     adapterType = CameraPermissionAdapter.self
                 case .location:
                     adapterType = LocationPermissionAdapter.self
-//                case .contacts:
-//                    adapterType = ContactsPermissionAdapter.self
+                case .contacts:
+                    adapterType = ContactsPermissionAdapter.self
                 case .photos:
                     adapterType = PhotosPermissionAdapter.self
                 case .calendarEvents:

--- a/FlintCore/Constraints/Permissions/DefaultPermissionChecker.swift
+++ b/FlintCore/Constraints/Permissions/DefaultPermissionChecker.swift
@@ -8,6 +8,10 @@
 
 import Foundation
 
+public enum ContactsEntity {
+    case contacts
+}
+
 /// The implementation of the system permission checker.
 ///
 /// This registers and verifies the approprite adapters and uses them to check the status

--- a/FlintCore/Constraints/Permissions/EventKitPermissionAdapter.swift
+++ b/FlintCore/Constraints/Permissions/EventKitPermissionAdapter.swift
@@ -35,7 +35,7 @@ class EventKitPermissionAdapter: SystemPermissionAdapter {
     static var isSupported: Bool {
 #if !os(tvOS)
         if #available(iOS 6, macOS 10.9, watchOS 2, *) {
-            let isLinked = libraryIsLinkedForClass("EKEventStore")
+            let isLinked = libraryIsLinkedForClass("EXXXXXKEventStore")
             return isLinked
         } else {
             return false

--- a/FlintCore/Constraints/Permissions/EventKitPermissionAdapter.swift
+++ b/FlintCore/Constraints/Permissions/EventKitPermissionAdapter.swift
@@ -26,7 +26,7 @@ class EventKitPermissionAdapter: SystemPermissionAdapter {
     static var isSupported: Bool {
 #if !os(tvOS)
         if #available(iOS 6, macOS 10.9, watchOS 2, *) {
-            let isLinked = libraryIsLinkedForClass("EKEventStore")
+            let isLinked = libraryIsLinkedForClass("XXXEventStore")
             return isLinked
         } else {
             return false
@@ -44,7 +44,7 @@ class EventKitPermissionAdapter: SystemPermissionAdapter {
     let usageDescriptionKey: String = "NSEventKitUsageDescription"
 #if canImport(EventKit)
     let entityType: EKEntityType
-    lazy var eventStore: AnyObject = { try! instantiate(classNamed: "EKEventStore") }()
+    lazy var eventStore: AnyObject = { try! instantiate(classNamed: "XXXEventStore") }()
     lazy var proxyEventStore: ProxyEventStore = { unsafeBitCast(self.eventStore, to: ProxyEventStore.self) }()
 #endif
 

--- a/FlintCore/Constraints/Permissions/EventKitPermissionAdapter.swift
+++ b/FlintCore/Constraints/Permissions/EventKitPermissionAdapter.swift
@@ -11,7 +11,7 @@ import Foundation
 import EventKit
 #endif
 
-@objc protocol EKProxyEventStore {
+@objc protocol ProxyEventStore {
     @objc(authorizationStatusForEntityType:)
     static func authorizationStatus(for entityType: EKEntityType) -> EKAuthorizationStatus
 
@@ -45,7 +45,7 @@ class EventKitPermissionAdapter: SystemPermissionAdapter {
 #if canImport(EventKit)
     let entityType: EKEntityType
     lazy var eventStore: AnyObject = { try! instantiate(classNamed: "EKEventStore") }()
-    lazy var proxyEventStore: EKProxyEventStore = { unsafeBitCast(self.eventStore, to: EKProxyEventStore.self) }()
+    lazy var proxyEventStore: ProxyEventStore = { unsafeBitCast(self.eventStore, to: ProxyEventStore.self) }()
 #endif
 
     var status: SystemPermissionStatus {

--- a/FlintCore/Constraints/Permissions/EventKitPermissionAdapter.swift
+++ b/FlintCore/Constraints/Permissions/EventKitPermissionAdapter.swift
@@ -26,7 +26,7 @@ class EventKitPermissionAdapter: SystemPermissionAdapter {
     static var isSupported: Bool {
 #if !os(tvOS)
         if #available(iOS 6, macOS 10.9, watchOS 2, *) {
-            let isLinked = libraryIsLinkedForClass("XXXEventStore")
+            let isLinked = libraryIsLinkedForClass("EKEventStore")
             return isLinked
         } else {
             return false
@@ -44,7 +44,7 @@ class EventKitPermissionAdapter: SystemPermissionAdapter {
     let usageDescriptionKey: String = "NSEventKitUsageDescription"
 #if canImport(EventKit)
     let entityType: EKEntityType
-    lazy var eventStore: AnyObject = { try! instantiate(classNamed: "XXXEventStore") }()
+    lazy var eventStore: AnyObject = { try! instantiate(classNamed: "EKEventStore") }()
     lazy var proxyEventStore: ProxyEventStore = { unsafeBitCast(self.eventStore, to: ProxyEventStore.self) }()
 #endif
 

--- a/FlintCore/Constraints/Permissions/MotionPermissionAdapter.swift
+++ b/FlintCore/Constraints/Permissions/MotionPermissionAdapter.swift
@@ -14,12 +14,15 @@ import CoreMotion
 typealias CMProxyMotionActivityQueryHandler = ([NSObject]?, Error?) -> Void
 
 @objc protocol ProxyMotionActivityManager {
+#if canImport(CoreMotion)
     @objc static func authorizationStatus() -> CMAuthorizationStatus
     
     @objc static var isActivityAvailable: Bool { get }
     
     @objc(queryActivityStartingFromDate:toDate:toQueue:withHandler:)
     func queryActivityStarting(from start: Date, to end: Date, to queue: OperationQueue, withHandler handler: @escaping CMProxyMotionActivityQueryHandler)
+#endif
+
 }
 
 /// Support: iOS 11+, macOS ⛔️, watchOS 4+, tvOS ⛔️

--- a/FlintCore/Constraints/Permissions/PhotosPermissionAdapter.swift
+++ b/FlintCore/Constraints/Permissions/PhotosPermissionAdapter.swift
@@ -11,12 +11,19 @@ import Foundation
 import Photos
 #endif
 
+ @objc enum ProxyPHAuthorizationStatus: Int {
+    case notDetermined
+    case restricted
+    case denied
+    case authorized
+}
+
 @objc protocol ProxyPhotoLibrary {
     // Don't declare these as static, we call them on the clasws
-    func authorizationStatus() -> PHAuthorizationStatus
+    func authorizationStatus() -> ProxyPHAuthorizationStatus
     
     @objc(requestAuthorization:)
-    func requestAuthorization(_ handler: @escaping (PHAuthorizationStatus) -> Void)
+    func requestAuthorization(_ handler: @escaping (ProxyPHAuthorizationStatus) -> Void)
 }
 
 /// Checks and authorises access to the Photo library on supported platforms
@@ -80,7 +87,7 @@ class PhotosPermissionAdapter: SystemPermissionAdapter {
 
 #if canImport(Photos)
     @available(iOS 8, tvOS 10, macOS 10.13, *)
-    func authStatusToPermissionStatus(_ authStatus: PHAuthorizationStatus) -> SystemPermissionStatus {
+    func authStatusToPermissionStatus(_ authStatus: ProxyPHAuthorizationStatus) -> SystemPermissionStatus {
 #if os(watchOS)
         return .unsupported
 #else

--- a/FlintCore/Constraints/Permissions/PhotosPermissionAdapter.swift
+++ b/FlintCore/Constraints/Permissions/PhotosPermissionAdapter.swift
@@ -11,6 +11,14 @@ import Foundation
 import Photos
 #endif
 
+@objc protocol ProxyPhotoLibrary {
+    // Don't declare these as static, we call them on the clasws
+    func authorizationStatus() -> PHAuthorizationStatus
+    
+    @objc(requestAuthorization:)
+    func requestAuthorization(_ handler: @escaping (PHAuthorizationStatus) -> Void)
+}
+
 /// Checks and authorises access to the Photo library on supported platforms
 ///
 /// Supports: iOS 8+, macOS 10.13+, watchOS ⛔️, tvOS 10+
@@ -20,7 +28,8 @@ class PhotosPermissionAdapter: SystemPermissionAdapter {
         return false
 #else
         if #available(iOS 8, macOS 10.13, tvOS 10, *) {
-            return true
+            let isLinked = libraryIsLinkedForClass("PHPhotoLibrary")
+            return isLinked
         } else {
             return false
         }
@@ -34,10 +43,13 @@ class PhotosPermissionAdapter: SystemPermissionAdapter {
     let permission: SystemPermissionConstraint
     let usageDescriptionKey: String = "NSPhotoLibraryUsageDescription"
 
+    lazy var photoLibrary: AnyObject = { NSClassFromString("PHPhotoLibrary")! }()
+    lazy var proxyPhotoLibrary: ProxyPhotoLibrary = { unsafeBitCast(self.photoLibrary, to: ProxyPhotoLibrary.self) }()
+    
     var status: SystemPermissionStatus {
 #if canImport(Photos)
         if #available(iOS 8, tvOS 10, macOS 10.13, *) {
-            return authStatusToPermissionStatus(PHPhotoLibrary.authorizationStatus())
+            return authStatusToPermissionStatus(proxyPhotoLibrary.authorizationStatus())
         } else {
             return .unsupported
         }
@@ -57,7 +69,7 @@ class PhotosPermissionAdapter: SystemPermissionAdapter {
         }
         
         if #available(iOS 8, tvOS 10, macOS 10.13, *) {
-            PHPhotoLibrary.requestAuthorization({status in
+            proxyPhotoLibrary.requestAuthorization({status in
                 completion(self, self.authStatusToPermissionStatus(status))
             })
         } else {
@@ -72,7 +84,7 @@ class PhotosPermissionAdapter: SystemPermissionAdapter {
 #if os(watchOS)
         return .unsupported
 #else
-        switch PHPhotoLibrary.authorizationStatus() {
+        switch proxyPhotoLibrary.authorizationStatus() {
             case .authorized: return .authorized
             case .denied: return .denied
             case .notDetermined: return .notDetermined

--- a/FlintCore/Constraints/Permissions/SpeechRecognitionPermissionAdapter.swift
+++ b/FlintCore/Constraints/Permissions/SpeechRecognitionPermissionAdapter.swift
@@ -16,7 +16,8 @@ class SpeechRecognitionPermissionAdapter: SystemPermissionAdapter {
     static var isSupported: Bool {
 #if canImport(Speech)
         if #available(iOS 10, *) {
-            return true
+            let isLinked = libraryIsLinkedForClass("SFSpeechRecognizer")
+            return isLinked
         } else {
             return false
         }

--- a/FlintCore/Constraints/Permissions/SpeechRecognitionPermissionAdapter.swift
+++ b/FlintCore/Constraints/Permissions/SpeechRecognitionPermissionAdapter.swift
@@ -42,9 +42,11 @@ class SpeechRecognitionPermissionAdapter: SystemPermissionAdapter {
     
     let permission: SystemPermissionConstraint
     
+#if canImport(Speech)
     lazy var speechRecognizerClass: AnyObject = { NSClassFromString("SFSpeechRecognizer")! }()
     lazy var proxySpeechRecognizerClass: ProxySpeechRecognizer = { unsafeBitCast(self.speechRecognizerClass, to: ProxySpeechRecognizer.self) }()
-    
+#endif
+
     var status: SystemPermissionStatus {
 #if canImport(Speech)
         if #available(iOS 10, *) {

--- a/FlintCore/Constraints/Permissions/SystemPermissionConstraint.swift
+++ b/FlintCore/Constraints/Permissions/SystemPermissionConstraint.swift
@@ -19,7 +19,7 @@ public enum SystemPermissionConstraint: Hashable, CustomStringConvertible {
     case camera
     case photos
     case location(usage: LocationUsage)
-    case contacts(entity: ContactsEntity)
+//    case contacts(entity: ContactsEntity)
     case calendarEvents
     case reminders
     case motion
@@ -27,7 +27,6 @@ public enum SystemPermissionConstraint: Hashable, CustomStringConvertible {
 
 // The rest of these are "coming soon"
 /*
-    case speechRecognition
     case bluetoothSharing
     case mediaLibrary
     case homeKit
@@ -47,10 +46,10 @@ public enum SystemPermissionConstraint: Hashable, CustomStringConvertible {
                     case .whenInUse: return "Location when in use"
                     case .always: return "Location always"
                 }
-            case .contacts(let entity):
-                switch entity {
-                    case .contacts: return "Contacts"
-                }
+//            case .contacts(let entity):
+//                switch entity {
+//                    case .contacts: return "Contacts"
+//                }
         }
     }
 }
@@ -62,7 +61,7 @@ extension SystemPermissionConstraint: FeatureConstraint {
             case .camera,
                  .calendarEvents,
                  .reminders,
-                 .contacts,
+//                 .contacts,
                  .photos,
                  .speechRecognition,
                  .motion:

--- a/FlintCore/Constraints/Permissions/SystemPermissionConstraint.swift
+++ b/FlintCore/Constraints/Permissions/SystemPermissionConstraint.swift
@@ -19,7 +19,7 @@ public enum SystemPermissionConstraint: Hashable, CustomStringConvertible {
     case camera
     case photos
     case location(usage: LocationUsage)
-//    case contacts(entity: ContactsEntity)
+    case contacts(entity: ContactsEntity)
     case calendarEvents
     case reminders
     case motion
@@ -46,10 +46,10 @@ public enum SystemPermissionConstraint: Hashable, CustomStringConvertible {
                     case .whenInUse: return "Location when in use"
                     case .always: return "Location always"
                 }
-//            case .contacts(let entity):
-//                switch entity {
-//                    case .contacts: return "Contacts"
-//                }
+            case .contacts(let entity):
+                switch entity {
+                    case .contacts: return "Contacts"
+                }
         }
     }
 }
@@ -61,7 +61,7 @@ extension SystemPermissionConstraint: FeatureConstraint {
             case .camera,
                  .calendarEvents,
                  .reminders,
-//                 .contacts,
+                 .contacts,
                  .photos,
                  .speechRecognition,
                  .motion:

--- a/FlintCore/Core/Flint.swift
+++ b/FlintCore/Core/Flint.swift
@@ -149,7 +149,7 @@ final public class Flint {
     /// registered by way of being subfeatures of a group.
     /// Only call this if you have not passed this feature to `setup` or `quickSetup`.
     public static func register(_ feature: FeatureDefinition.Type) {
-        flintUsagePrecondition(!(feature is FeatureGroup), "You must call register(group:) with feature groups")
+        flintUsagePrecondition(!(feature is FeatureGroup.Type), "You must call register(group:) with feature groups")
         FlintInternal.logger?.debug("Preparing feature: \(feature)")
         _register(feature)
     }

--- a/FlintCore/Core/Flint.swift
+++ b/FlintCore/Core/Flint.swift
@@ -11,7 +11,7 @@ import Foundation
 import CoreSpotlight
 #endif
 #if os(iOS) || os(macOS)
-import Intents
+//import Intents
 #endif
 #if canImport(ClassKit)
 import ClassKit
@@ -298,9 +298,9 @@ final public class Flint {
                 default:
 #if os(iOS) || os(macOS)
                     // Check for a Siri intent
-                    if let _ = activity.interaction {
-                        source = .continueActivity(type: .siri)
-                    }
+//                    if let _ = activity.interaction {
+//                        source = .continueActivity(type: .siri)
+//                    }
 #endif
 
 #if canImport(ClassKit)

--- a/FlintCore/Core/Flint.swift
+++ b/FlintCore/Core/Flint.swift
@@ -10,11 +10,16 @@ import Foundation
 #if canImport(CoreSpotlight)
 import CoreSpotlight
 #endif
-#if os(iOS) || os(macOS)
-//import Intents
-#endif
 #if canImport(ClassKit)
 import ClassKit
+#endif
+
+#if os(iOS) || os(macOS)
+/// Temporary workaround for Intents having an implicit dependency on Contacts framework.
+/// Radar #41946218 — "Importing Intents forces app to provide NSContactsUsageDescription"
+@objc fileprivate protocol IntentsNSUserActivityExtension {
+    @objc var interaction: AnyObject? { get }
+}
 #endif
 
 /// This is the Flint class, with entry points for application-level convenience functions and metadata.
@@ -298,9 +303,10 @@ final public class Flint {
                 default:
 #if os(iOS) || os(macOS)
                     // Check for a Siri intent
-//                    if let _ = activity.interaction {
-//                        source = .continueActivity(type: .siri)
-//                    }
+                    let interactionActivity = unsafeBitCast(activity, to: IntentsNSUserActivityExtension.self)
+                    if let _ = interactionActivity.interaction {
+                        source = .continueActivity(type: .siri)
+                    }
 #endif
 
 #if canImport(ClassKit)

--- a/FlintCore/Utils/DynamicLibraryBinding.swift
+++ b/FlintCore/Utils/DynamicLibraryBinding.swift
@@ -88,10 +88,32 @@ func dynamicBindIntArgsIntReturn(toStaticMethod methodName: String, on className
     }
 }
 
+func dynamicBindUIntArgsIntReturn(toStaticMethod methodName: String, on className: String) throws -> (UInt) -> Int {
+    let invocation = try DynamicInvocation(className: className, staticMethodName: methodName)
+    return { (arg1: UInt) in
+        typealias FuncType = (AnyObject, Selector, UInt) -> Int
+        return invocation.perform { (functionGenerator: () -> FuncType, instance, selector) in
+            let function: FuncType = functionGenerator()
+            return function(instance, selector, arg1)
+        }
+    }
+}
+
 func dynamicBindIntAndBoolErrorOptionalClosureReturnVoid(toInstanceMethod methodName: String, on object: AnyObject) throws -> (Int, (Bool, Error?) -> Void) -> Void {
     let invocation = try DynamicInvocation(object: object, methodName: methodName)
     return { (arg1: Int, arg2: (Bool, Error?) -> Void) in
         typealias FuncType = (AnyObject, Selector, Int, (Bool, Error?) -> Void) -> Void
+        invocation.perform { (functionGenerator: () -> FuncType, instance, selector) in
+            let function: FuncType = functionGenerator()
+            function(instance, selector, arg1, arg2)
+        }
+    }
+}
+
+func dynamicBindUIntAndBoolErrorOptionalClosureReturnVoid(toInstanceMethod methodName: String, on object: AnyObject) throws -> (UInt, (Bool, Error?) -> Void) -> Void {
+    let invocation = try DynamicInvocation(object: object, methodName: methodName)
+    return { (arg1: UInt, arg2: (Bool, Error?) -> Void) in
+        typealias FuncType = (AnyObject, Selector, UInt, (Bool, Error?) -> Void) -> Void
         invocation.perform { (functionGenerator: () -> FuncType, instance, selector) in
             let function: FuncType = functionGenerator()
             function(instance, selector, arg1, arg2)

--- a/FlintCore/Utils/DynamicLibraryBinding.swift
+++ b/FlintCore/Utils/DynamicLibraryBinding.swift
@@ -1,0 +1,127 @@
+//
+//  DynamicLibraryBinding.swift
+//  FlintCore
+//
+//  Created by Marc Palmer on 04/07/2018.
+//  Copyright © 2018 Montana Floss Co. Ltd. All rights reserved.
+//
+import Foundation
+
+enum DynamicBindError: Error {
+    case classNotFound
+    case methodNotFound
+}
+
+struct DynamicInvocation {
+    let instance: AnyObject
+    let method: IMP
+    let selector: Selector
+
+    init(instance: AnyObject, method: IMP, selector: Selector) {
+        self.instance = instance
+        self.method = method
+        self.selector = selector
+    }
+
+    init(className: String, staticMethodName: String) throws {
+        guard let targetClass = NSClassFromString(className) else {
+            throw DynamicBindError.classNotFound
+        }
+        instance = targetClass
+        selector = NSSelectorFromString(staticMethodName)
+        guard let method = targetClass.method(for: selector) else {
+            throw DynamicBindError.methodNotFound
+        }
+        self.method = method
+    }
+    
+    init(object: AnyObject, methodName: String) throws {
+        instance = object
+        selector = NSSelectorFromString(methodName)
+        guard let method = object.method(for: selector) else {
+            throw DynamicBindError.methodNotFound
+        }
+        self.method = method
+    }
+    
+    func perform<T, ReturnType>(block: (_ functionGenerator: () -> T, _ instance: AnyObject, _ selector: Selector) -> ReturnType) -> ReturnType where T: Any {
+        let f: () -> T = {
+            return unsafeBitCast(self.method, to: T.self)
+        }
+        return block(f, instance, selector)
+    }
+}
+
+func dynamicBind(toInstance object: AnyObject, selector: Selector) throws -> DynamicInvocation {
+    guard let method = object.method(for: selector) else {
+        throw DynamicBindError.methodNotFound
+    }
+    return DynamicInvocation(instance: object, method: method, selector: selector)
+}
+
+func instantiate(classNamed className: String) throws -> NSObject {
+    guard let targetClass = NSClassFromString(className) as? NSObject.Type else {
+        throw DynamicBindError.classNotFound
+    }
+    return targetClass.init()
+}
+
+func dynamicBindIntReturn(toStaticMethod methodName: String, on className: String) throws -> () -> Int {
+    let invocation = try DynamicInvocation(className: className, staticMethodName: methodName)
+    return {
+        typealias FuncType = (AnyObject, Selector) -> Int
+        return invocation.perform { (functionGenerator: () -> FuncType, instance, selector) in
+            let function: FuncType = functionGenerator()
+            return function(instance, selector)
+        }
+    }
+}
+
+func dynamicBindIntArgsIntReturn(toStaticMethod methodName: String, on className: String) throws -> (Int) -> Int {
+    let invocation = try DynamicInvocation(className: className, staticMethodName: methodName)
+    return { (arg1: Int) in
+        typealias FuncType = (AnyObject, Selector, Int) -> Int
+        return invocation.perform { (functionGenerator: () -> FuncType, instance, selector) in
+            let function: FuncType = functionGenerator()
+            return function(instance, selector, arg1)
+        }
+    }
+}
+
+func dynamicBindIntAndBoolErrorOptionalClosureReturnVoid(toInstanceMethod methodName: String, on object: AnyObject) throws -> (Int, (Bool, Error?) -> Void) -> Void {
+    let invocation = try DynamicInvocation(object: object, methodName: methodName)
+    return { (arg1: Int, arg2: (Bool, Error?) -> Void) in
+        typealias FuncType = (AnyObject, Selector, Int, (Bool, Error?) -> Void) -> Void
+        invocation.perform { (functionGenerator: () -> FuncType, instance, selector) in
+            let function: FuncType = functionGenerator()
+            function(instance, selector, arg1, arg2)
+        }
+    }
+}
+
+/// Support zero-arg instance function.
+/// Input/output func type is: () -> T
+/// Internally we current the instance and selector, and return a func that has these bound
+func dynamicBindVoidReturn(toInstanceMethod methodName: String, on object: AnyObject) throws -> () -> Void {
+    let invocation = try DynamicInvocation(object: object, methodName: methodName)
+    return {
+        typealias FuncType = (AnyObject, Selector) -> Void
+        invocation.perform { (functionGenerator: () -> FuncType, instance, selector) in
+            let function: FuncType = functionGenerator()
+            function(instance, selector)
+        }
+    }
+}
+
+func dynamicBindIntReturn(toInstanceMethod methodName: String, on object: AnyObject) throws -> () -> Int {
+    let selector = NSSelectorFromString(methodName)
+    guard let method = object.method(for: selector) else {
+        throw DynamicBindError.methodNotFound
+    }
+    
+    typealias funcType = @convention (c) (AnyObject, Selector) -> Int
+    let dynamicFunction: funcType = unsafeBitCast(method, to: funcType.self)
+    return {
+        return dynamicFunction(object, selector)
+    }
+}

--- a/FlintCore/Utils/DynamicLibraryBinding.swift
+++ b/FlintCore/Utils/DynamicLibraryBinding.swift
@@ -12,51 +12,9 @@ enum DynamicBindError: Error {
     case methodNotFound
 }
 
-struct DynamicInvocation {
-    let instance: AnyObject
-    let method: IMP
-    let selector: Selector
-
-    init(instance: AnyObject, method: IMP, selector: Selector) {
-        self.instance = instance
-        self.method = method
-        self.selector = selector
-    }
-
-    init(className: String, staticMethodName: String) throws {
-        guard let targetClass = NSClassFromString(className) else {
-            throw DynamicBindError.classNotFound
-        }
-        instance = targetClass
-        selector = NSSelectorFromString(staticMethodName)
-        guard let method = targetClass.method(for: selector) else {
-            throw DynamicBindError.methodNotFound
-        }
-        self.method = method
-    }
-    
-    init(object: AnyObject, methodName: String) throws {
-        instance = object
-        selector = NSSelectorFromString(methodName)
-        guard let method = object.method(for: selector) else {
-            throw DynamicBindError.methodNotFound
-        }
-        self.method = method
-    }
-    
-    func perform<T, ReturnType>(block: (_ functionGenerator: () -> T, _ instance: AnyObject, _ selector: Selector) -> ReturnType) -> ReturnType where T: Any {
-        let f: () -> T = {
-            return unsafeBitCast(self.method, to: T.self)
-        }
-        return block(f, instance, selector)
-    }
-}
-
-func dynamicBind(toInstance object: AnyObject, selector: Selector) throws -> DynamicInvocation {
-    guard let method = object.method(for: selector) else {
-        throw DynamicBindError.methodNotFound
-    }
-    return DynamicInvocation(instance: object, method: method, selector: selector)
+/// Test if a class can be loaded from a given library.
+func libraryIsLinkedForClass(_ className: String) -> Bool {
+    return NSClassFromString(className) != nil
 }
 
 func instantiate(classNamed className: String) throws -> NSObject {
@@ -66,84 +24,139 @@ func instantiate(classNamed className: String) throws -> NSObject {
     return targetClass.init()
 }
 
-func dynamicBindIntReturn(toStaticMethod methodName: String, on className: String) throws -> () -> Int {
-    let invocation = try DynamicInvocation(className: className, staticMethodName: methodName)
-    return {
-        typealias FuncType = (AnyObject, Selector) -> Int
-        return invocation.perform { (functionGenerator: () -> FuncType, instance, selector) in
-            let function: FuncType = functionGenerator()
-            return function(instance, selector)
-        }
-    }
-}
-
-func dynamicBindIntArgsIntReturn(toStaticMethod methodName: String, on className: String) throws -> (Int) -> Int {
-    let invocation = try DynamicInvocation(className: className, staticMethodName: methodName)
-    return { (arg1: Int) in
-        typealias FuncType = (AnyObject, Selector, Int) -> Int
-        return invocation.perform { (functionGenerator: () -> FuncType, instance, selector) in
-            let function: FuncType = functionGenerator()
-            return function(instance, selector, arg1)
-        }
-    }
-}
-
-func dynamicBindUIntArgsIntReturn(toStaticMethod methodName: String, on className: String) throws -> (UInt) -> Int {
-    let invocation = try DynamicInvocation(className: className, staticMethodName: methodName)
-    return { (arg1: UInt) in
-        typealias FuncType = (AnyObject, Selector, UInt) -> Int
-        return invocation.perform { (functionGenerator: () -> FuncType, instance, selector) in
-            let function: FuncType = functionGenerator()
-            return function(instance, selector, arg1)
-        }
-    }
-}
-
-func dynamicBindIntAndBoolErrorOptionalClosureReturnVoid(toInstanceMethod methodName: String, on object: AnyObject) throws -> (Int, (Bool, Error?) -> Void) -> Void {
-    let invocation = try DynamicInvocation(object: object, methodName: methodName)
-    return { (arg1: Int, arg2: (Bool, Error?) -> Void) in
-        typealias FuncType = (AnyObject, Selector, Int, (Bool, Error?) -> Void) -> Void
-        invocation.perform { (functionGenerator: () -> FuncType, instance, selector) in
-            let function: FuncType = functionGenerator()
-            function(instance, selector, arg1, arg2)
-        }
-    }
-}
-
-func dynamicBindUIntAndBoolErrorOptionalClosureReturnVoid(toInstanceMethod methodName: String, on object: AnyObject) throws -> (UInt, (Bool, Error?) -> Void) -> Void {
-    let invocation = try DynamicInvocation(object: object, methodName: methodName)
-    return { (arg1: UInt, arg2: (Bool, Error?) -> Void) in
-        typealias FuncType = (AnyObject, Selector, UInt, (Bool, Error?) -> Void) -> Void
-        invocation.perform { (functionGenerator: () -> FuncType, instance, selector) in
-            let function: FuncType = functionGenerator()
-            function(instance, selector, arg1, arg2)
-        }
-    }
-}
-
-/// Support zero-arg instance function.
-/// Input/output func type is: () -> T
-/// Internally we current the instance and selector, and return a func that has these bound
-func dynamicBindVoidReturn(toInstanceMethod methodName: String, on object: AnyObject) throws -> () -> Void {
-    let invocation = try DynamicInvocation(object: object, methodName: methodName)
-    return {
-        typealias FuncType = (AnyObject, Selector) -> Void
-        invocation.perform { (functionGenerator: () -> FuncType, instance, selector) in
-            let function: FuncType = functionGenerator()
-            function(instance, selector)
-        }
-    }
-}
-
-func dynamicBindIntReturn(toInstanceMethod methodName: String, on object: AnyObject) throws -> () -> Int {
-    let selector = NSSelectorFromString(methodName)
-    guard let method = object.method(for: selector) else {
-        throw DynamicBindError.methodNotFound
-    }
-    
-    typealias funcType = @convention (c) (AnyObject, Selector) -> Int
-    let dynamicFunction: funcType = unsafeBitCast(method, to: funcType.self)
-    return {
-        return dynamicFunction(object, selector)
-    }
-}
+//
+//struct DynamicInvocation {
+//    let instance: AnyObject
+//    let method: IMP
+//    let selector: Selector
+//
+//    init(instance: AnyObject, method: IMP, selector: Selector) {
+//        self.instance = instance
+//        self.method = method
+//        self.selector = selector
+//    }
+//
+//    init(className: String, staticMethodName: String) throws {
+//        guard let targetClass = NSClassFromString(className) else {
+//            throw DynamicBindError.classNotFound
+//        }
+//        instance = targetClass
+//        selector = NSSelectorFromString(staticMethodName)
+//        guard let method = targetClass.method(for: selector) else {
+//            throw DynamicBindError.methodNotFound
+//        }
+//        self.method = method
+//    }
+//
+//    init(object: AnyObject, methodName: String) throws {
+//        instance = object
+//        selector = NSSelectorFromString(methodName)
+//        guard let method = object.method(for: selector) else {
+//            throw DynamicBindError.methodNotFound
+//        }
+//        self.method = method
+//    }
+//
+//    func perform<T, ReturnType>(block: (_ functionGenerator: () -> T, _ instance: AnyObject, _ selector: Selector) -> ReturnType) -> ReturnType where T: Any {
+//        let f: () -> T = {
+//            return unsafeBitCast(self.method, to: T.self)
+//        }
+//        return block(f, instance, selector)
+//    }
+//}
+//
+//func dynamicBind(toInstance object: AnyObject, selector: Selector) throws -> DynamicInvocation {
+//    guard let method = object.method(for: selector) else {
+//        throw DynamicBindError.methodNotFound
+//    }
+//    return DynamicInvocation(instance: object, method: method, selector: selector)
+//}
+//
+//func instantiate(classNamed className: String) throws -> NSObject {
+//    guard let targetClass = NSClassFromString(className) as? NSObject.Type else {
+//        throw DynamicBindError.classNotFound
+//    }
+//    return targetClass.init()
+//}
+//
+//func dynamicBindIntReturn(toStaticMethod methodName: String, on className: String) throws -> () -> Int {
+//    let invocation = try DynamicInvocation(className: className, staticMethodName: methodName)
+//    return {
+//        typealias FuncType = @convention(c) (AnyObject, Selector) -> Int
+//        return invocation.perform { (functionGenerator: () -> FuncType, instance, selector) in
+//            let function: FuncType = functionGenerator()
+//            return function(instance, selector)
+//        }
+//    }
+//}
+//
+//func dynamicBindIntArgsIntReturn(toStaticMethod methodName: String, on className: String) throws -> (Int) -> Int {
+//    let invocation = try DynamicInvocation(className: className, staticMethodName: methodName)
+//    return { (arg1: Int) in
+//        typealias FuncType = @convention(c) (AnyObject, Selector, Int) -> Int
+//        return invocation.perform { (functionGenerator: () -> FuncType, instance, selector) in
+//            let function: FuncType = functionGenerator()
+//            return function(instance, selector, arg1)
+//        }
+//    }
+//}
+//
+//func dynamicBindUIntArgsIntReturn(toStaticMethod methodName: String, on className: String) throws -> (UInt) -> Int {
+//    let invocation = try DynamicInvocation(className: className, staticMethodName: methodName)
+//    return { (arg1: UInt) in
+//        typealias FuncType = @convention(c) (AnyObject, Selector, UInt) -> Int
+//        return invocation.perform { (functionGenerator: () -> FuncType, instance, selector) in
+//            let function: FuncType = functionGenerator()
+//            return function(instance, selector, arg1)
+//        }
+//    }
+//}
+//
+//func dynamicBindIntAndBoolErrorOptionalClosureReturnVoid(toInstanceMethod methodName: String, on object: AnyObject) throws -> (Int, (Bool, Error?) -> Void) -> Void {
+//    let invocation = try DynamicInvocation(object: object, methodName: methodName)
+//    return { (arg1: Int, arg2: (Bool, Error?) -> Void) in
+//        typealias FuncType = @convention(c) (AnyObject, Selector, Int, (Bool, Error?) -> Void) -> Void
+//        invocation.perform { (functionGenerator: () -> FuncType, instance, selector) in
+//            let function: FuncType = functionGenerator()
+//            function(instance, selector, arg1, arg2)
+//        }
+//    }
+//}
+//
+//func dynamicBindUIntAndBoolErrorOptionalClosureReturnVoid(toInstanceMethod methodName: String, on object: AnyObject) throws -> (UInt, (Bool, Error?) -> Void) -> Void {
+//    let invocation = try DynamicInvocation(object: object, methodName: methodName)
+//    return { (arg1: UInt, arg2: (Bool, Error?) -> Void) in
+//        typealias FuncType = @convention(c) (AnyObject, Selector, UInt, (Bool, Error?) -> Void) -> Void
+//        invocation.perform { (functionGenerator: () -> FuncType, instance, selector) in
+//            let function: FuncType = functionGenerator()
+//            function(instance, selector, arg1, arg2)
+//        }
+//    }
+//}
+//
+///// Support zero-arg instance function.
+///// Input/output func type is: () -> T
+///// Internally we current the instance and selector, and return a func that has these bound
+//func dynamicBindVoidReturn(toInstanceMethod methodName: String, on object: AnyObject) throws -> () -> Void {
+//    let invocation = try DynamicInvocation(object: object, methodName: methodName)
+//    return {
+//        typealias FuncType = @convention(c) (AnyObject, Selector) -> Void
+//        invocation.perform { (functionGenerator: () -> FuncType, instance, selector) in
+//            let function: FuncType = functionGenerator()
+//            function(instance, selector)
+//        }
+//    }
+//}
+//
+//func dynamicBindIntReturn(toInstanceMethod methodName: String, on object: AnyObject) throws -> () -> Int {
+//    let selector = NSSelectorFromString(methodName)
+//    guard let method = object.method(for: selector) else {
+//        throw DynamicBindError.methodNotFound
+//    }
+//
+//    typealias funcType = @convention (c) (AnyObject, Selector) -> Int
+//    let dynamicFunction: funcType = unsafeBitCast(method, to: funcType.self)
+//    return {
+//        return dynamicFunction(object, selector)
+//    }
+//}

--- a/FlintUI.xcodeproj/project.pbxproj
+++ b/FlintUI.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		49D5796B20618AD9006EE0C9 /* ActionDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D5796A20618AD9006EE0C9 /* ActionDetailViewController.swift */; };
 		49D579702063C6E0006EE0C9 /* FeatureBrowserViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D5796F2063C6E0006EE0C9 /* FeatureBrowserViewController.swift */; };
 		49DB9233206FD67C00F758DC /* FocusLogViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB9230206FD65B00F758DC /* FocusLogViewController.swift */; };
+		49EB9A7720EE35740034D07D /* EventKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 49EB9A7620EE35730034D07D /* EventKit.framework */; };
 		49F5DA7D2065121F00DA0CD3 /* TimelineEntryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F5DA7C2065121F00DA0CD3 /* TimelineEntryViewController.swift */; };
 /* End PBXBuildFile section */
 
@@ -111,6 +112,7 @@
 		49D5796A20618AD9006EE0C9 /* ActionDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionDetailViewController.swift; sourceTree = "<group>"; };
 		49D5796F2063C6E0006EE0C9 /* FeatureBrowserViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureBrowserViewController.swift; sourceTree = "<group>"; };
 		49DB9230206FD65B00F758DC /* FocusLogViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusLogViewController.swift; sourceTree = "<group>"; };
+		49EB9A7620EE35730034D07D /* EventKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = EventKit.framework; path = System/Library/Frameworks/EventKit.framework; sourceTree = SDKROOT; };
 		49F5DA7C2065121F00DA0CD3 /* TimelineEntryViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimelineEntryViewController.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
@@ -119,6 +121,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				49EB9A7720EE35740034D07D /* EventKit.framework in Frameworks */,
 				4908957A208F48CA0022E0A7 /* FlintCore.framework in Frameworks */,
 				49089567208F471C0022E0A7 /* FlintUI.framework in Frameworks */,
 				49089577208F48B20022E0A7 /* ZIPFoundation.framework in Frameworks */,
@@ -186,6 +189,7 @@
 		496F8EF9203ED479003AB29B /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
+				49EB9A7620EE35730034D07D /* EventKit.framework */,
 				497BFF1F20C7F55300E70157 /* FlintCore.framework */,
 				49089574208F48060022E0A7 /* ZIPFoundation.framework */,
 				49089572208F47C10022E0A7 /* FlintCore.framework */,
@@ -487,6 +491,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_MODULES_AUTOLINK = NO;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 5LUNBYMD4J;
@@ -511,6 +516,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				CLANG_MODULES_AUTOLINK = NO;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
 				DEVELOPMENT_TEAM = 5LUNBYMD4J;
@@ -655,6 +661,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				CLANG_MODULES_AUTOLINK = NO;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;
@@ -683,6 +690,7 @@
 			isa = XCBuildConfiguration;
 			buildSettings = {
 				CLANG_ENABLE_MODULES = YES;
+				CLANG_MODULES_AUTOLINK = NO;
 				CODE_SIGN_IDENTITY = "";
 				CODE_SIGN_STYLE = Automatic;
 				DEFINES_MODULE = YES;

--- a/FlintUI.xcodeproj/project.pbxproj
+++ b/FlintUI.xcodeproj/project.pbxproj
@@ -39,7 +39,6 @@
 		49D5796B20618AD9006EE0C9 /* ActionDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D5796A20618AD9006EE0C9 /* ActionDetailViewController.swift */; };
 		49D579702063C6E0006EE0C9 /* FeatureBrowserViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D5796F2063C6E0006EE0C9 /* FeatureBrowserViewController.swift */; };
 		49DB9233206FD67C00F758DC /* FocusLogViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB9230206FD65B00F758DC /* FocusLogViewController.swift */; };
-		49EB9A7720EE35740034D07D /* EventKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 49EB9A7620EE35730034D07D /* EventKit.framework */; };
 		49F5DA7D2065121F00DA0CD3 /* TimelineEntryViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F5DA7C2065121F00DA0CD3 /* TimelineEntryViewController.swift */; };
 /* End PBXBuildFile section */
 
@@ -121,7 +120,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				49EB9A7720EE35740034D07D /* EventKit.framework in Frameworks */,
 				4908957A208F48CA0022E0A7 /* FlintCore.framework in Frameworks */,
 				49089567208F471C0022E0A7 /* FlintUI.framework in Frameworks */,
 				49089577208F48B20022E0A7 /* ZIPFoundation.framework in Frameworks */,

--- a/FlintUISandbox/AppDelegate.swift
+++ b/FlintUISandbox/AppDelegate.swift
@@ -45,7 +45,7 @@ final class FakeFeature: ConditionalFeature {
         requirements.permission(.contacts(entity: .contacts))
         requirements.permission(.calendarEvents)
         requirements.permission(.reminders)
-//        requirements.permission(.motion)
+        requirements.permission(.motion)
         requirements.permission(.speechRecognition)
     }
 }

--- a/FlintUISandbox/Info.plist
+++ b/FlintUISandbox/Info.plist
@@ -20,12 +20,8 @@
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>
 	<true/>
-	<key>NSCalendarsUsageDescription</key>
-	<string>Testing calendar access</string>
 	<key>NSCameraUsageDescription</key>
 	<string>Testing camera permission</string>
-	<key>NSContactsUsageDescription</key>
-	<string>Contacts testing</string>
 	<key>NSPhotoLibraryUsageDescription</key>
 	<string>Photos testing</string>
 	<key>NSRemindersUsageDescription</key>


### PR DESCRIPTION
We had problems with app store processing rejections for missing `NSContactsUsageDescription` and `NSCalendarsUsageDescription` plist keys when these APIs were not being used by the app itself.

This was caused by:

* Implicit dependency on Contacts framework by linking against Intents for the `interaction` property extension on NSUserActivity
* Strongly linking Contacts and EvenKit, via explicit `import Contacts` etc.
* Even without imports and attempted unsafeBitcast to private @objc protocols we were still rejected for using the selectors for requesting access

So we have some dynamic binding code here used for Contacts, EventKit and the small property access for Interns. We still link against frameworks the user may not be using, so we need to improve that in future for performance but it does not currently cause rejection issues.

**NOTE THAT THIS IS A TEMPORARY SOLUTION**

At least that is the hope at the moment. There are concerns this will be caught later by App Store processing/review — although this technique is well-used for various APIs. We have some possibilities for less distasteful solutions:

1. Microframeworks, with one for each permission adapter. This means uses must update their Cartfile when adding new persmissions, but we can alert them to this at runtime. This adds runtime overhead also, with more (but small) frameworks being linked. This would neatly solve the import problem however and allow those frameworks to pull in the expected APIs without weak linking and proxy type shenanigans

2. An app-side protocol mechanism where the permissions interface to the various APIs is mimicked without requiring imports in FlintCore, and the permission adapters call out to these instances which the app would have to assign to e.g. `Flint.contactStore`.

