### PR TITLE
Changes InputType to conform to FlintLoggable

### DIFF
--- a/FlintCore.xcodeproj/project.pbxproj
+++ b/FlintCore.xcodeproj/project.pbxproj
@@ -540,6 +540,10 @@
 		49A99A081FF9073C00A64E8C /* AggregatingLoggerOutput.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49A99A071FF9073C00A64E8C /* AggregatingLoggerOutput.swift */; };
 		49B06F0D20A4BCE8004564E1 /* AVFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 49B06F0C20A4BCE8004564E1 /* AVFoundation.framework */; };
 		49B06F1120A4C274004564E1 /* ZIPFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 49FC45F520A46E5E00679F97 /* ZIPFoundation.framework */; };
+		49B4DCBF20F512D5006A6241 /* NSUserActivity+FlintAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B4DCBE20F512D5006A6241 /* NSUserActivity+FlintAdditions.swift */; };
+		49B4DCC020F512D5006A6241 /* NSUserActivity+FlintAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B4DCBE20F512D5006A6241 /* NSUserActivity+FlintAdditions.swift */; };
+		49B4DCC120F512D5006A6241 /* NSUserActivity+FlintAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B4DCBE20F512D5006A6241 /* NSUserActivity+FlintAdditions.swift */; };
+		49B4DCC220F512D5006A6241 /* NSUserActivity+FlintAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B4DCBE20F512D5006A6241 /* NSUserActivity+FlintAdditions.swift */; };
 		49BC1C4520795E9E00A7FC77 /* LIFOArrayQueueDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49BC1C4420795E9E00A7FC77 /* LIFOArrayQueueDataSource.swift */; };
 		49BC1C4620795E9E00A7FC77 /* LIFOArrayQueueDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49BC1C4420795E9E00A7FC77 /* LIFOArrayQueueDataSource.swift */; };
 		49BC1C4720795E9E00A7FC77 /* LIFOArrayQueueDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49BC1C4420795E9E00A7FC77 /* LIFOArrayQueueDataSource.swift */; };
@@ -560,6 +564,10 @@
 		49CCF0CC1F8BB23E00F7020E /* ActionDispatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49CCF0CA1F8BB23600F7020E /* ActionDispatcher.swift */; };
 		49CCF0CD1F8BB24000F7020E /* ActionSession.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49CCF0C81F8BB23600F7020E /* ActionSession.swift */; };
 		49CCF0D01F8BB25800F7020E /* Logging.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49CCF0CF1F8BB25600F7020E /* Logging.swift */; };
+		49CF4D3920F5281C0009FFF4 /* FlintLoggable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49CF4D3820F5281C0009FFF4 /* FlintLoggable.swift */; };
+		49CF4D3A20F5281C0009FFF4 /* FlintLoggable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49CF4D3820F5281C0009FFF4 /* FlintLoggable.swift */; };
+		49CF4D3B20F5281C0009FFF4 /* FlintLoggable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49CF4D3820F5281C0009FFF4 /* FlintLoggable.swift */; };
+		49CF4D3C20F5281C0009FFF4 /* FlintLoggable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49CF4D3820F5281C0009FFF4 /* FlintLoggable.swift */; };
 		49D24B5620ADD35900649BB4 /* RegexURLPattern.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D24B5520ADD35900649BB4 /* RegexURLPattern.swift */; };
 		49D24B5720ADD35900649BB4 /* RegexURLPattern.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D24B5520ADD35900649BB4 /* RegexURLPattern.swift */; };
 		49D24B5820ADD35900649BB4 /* RegexURLPattern.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D24B5520ADD35900649BB4 /* RegexURLPattern.swift */; };
@@ -880,6 +888,7 @@
 		49B06F0C20A4BCE8004564E1 /* AVFoundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = AVFoundation.framework; path = Platforms/AppleTVOS.platform/Developer/SDKs/AppleTVOS11.3.sdk/System/Library/Frameworks/AVFoundation.framework; sourceTree = DEVELOPER_DIR; };
 		49B06F1820A4C5AC004564E1 /* FlintCore_watchOSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlintCore_watchOSTests.swift; sourceTree = "<group>"; };
 		49B06F1A20A4C5AC004564E1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		49B4DCBE20F512D5006A6241 /* NSUserActivity+FlintAdditions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSUserActivity+FlintAdditions.swift"; sourceTree = "<group>"; };
 		49BC1C4420795E9E00A7FC77 /* LIFOArrayQueueDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LIFOArrayQueueDataSource.swift; sourceTree = "<group>"; };
 		49BC1C4920795EB800A7FC77 /* UniquelyIdentifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniquelyIdentifiable.swift; sourceTree = "<group>"; };
 		49BC1C5620867C2400A7FC77 /* ActionStack.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActionStack.swift; sourceTree = "<group>"; };
@@ -894,6 +903,7 @@
 		49CCF0C91F8BB23600F7020E /* FeatureDefinition.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureDefinition.swift; sourceTree = "<group>"; };
 		49CCF0CA1F8BB23600F7020E /* ActionDispatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionDispatcher.swift; sourceTree = "<group>"; };
 		49CCF0CF1F8BB25600F7020E /* Logging.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logging.swift; sourceTree = "<group>"; };
+		49CF4D3820F5281C0009FFF4 /* FlintLoggable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlintLoggable.swift; sourceTree = "<group>"; };
 		49D24B5520ADD35900649BB4 /* RegexURLPattern.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RegexURLPattern.swift; sourceTree = "<group>"; };
 		49D24B5A20B3054C00649BB4 /* URLMappingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = URLMappingTests.swift; sourceTree = "<group>"; };
 		49D447F41FEC69F900DBB352 /* Feature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Feature.swift; sourceTree = "<group>"; };
@@ -1127,6 +1137,7 @@
 				49F6824320D2C0B200B02318 /* ActivityMetadataRepresentable.swift */,
 				49A62C8220D2FDF800264606 /* PerformIncomingActivityAction.swift */,
 				49A62C8720D2FF3B00264606 /* ActionActivityMappings.swift */,
+				49B4DCBE20F512D5006A6241 /* NSUserActivity+FlintAdditions.swift */,
 			);
 			path = Activities;
 			sourceTree = "<group>";
@@ -1235,6 +1246,7 @@
 				49F2CF251FF7EB78004F16EF /* NoInput.swift */,
 				49F2CF211FF7B56B004F16EF /* NoPresenter.swift */,
 				49819EB91FC9C2310013AF55 /* StaticActionBinding.swift */,
+				49CF4D3820F5281C0009FFF4 /* FlintLoggable.swift */,
 			);
 			path = Actions;
 			sourceTree = "<group>";
@@ -1801,6 +1813,7 @@
 				494F59162098AA280075E7EE /* PlatformVersionConstraint.swift in Sources */,
 				498A894D2068FF5200457D66 /* TimelineFeature.swift in Sources */,
 				494F59482098ABE90075E7EE /* DefaultFeatureConstraintsEvaluator.swift in Sources */,
+				49B4DCC020F512D5006A6241 /* NSUserActivity+FlintAdditions.swift in Sources */,
 				49935BEB206D23E400CB2B5D /* LIFOArrayQueue.swift in Sources */,
 				496F8FC5203EEBDA003AB29B /* FlintAppInfo.swift in Sources */,
 				49F6824520D2C0B200B02318 /* ActivityMetadataRepresentable.swift in Sources */,
@@ -1874,6 +1887,7 @@
 				49935BF0206D250400CB2B5D /* TimeOrderedResultsController.swift in Sources */,
 				496F8F88203EEBBA003AB29B /* StoreKitPurchaseTracker.swift in Sources */,
 				49F6824020D2C07100B02318 /* ActivityMetadataBuilder.swift in Sources */,
+				49CF4D3A20F5281C0009FFF4 /* FlintLoggable.swift in Sources */,
 				496136DF2099028F00291885 /* LocationUsage.swift in Sources */,
 				496F8F87203EEBBA003AB29B /* DefaultAvailabilityChecker.swift in Sources */,
 				496F8FB0203EEBD3003AB29B /* URLMappingsBuilder.swift in Sources */,
@@ -1977,6 +1991,7 @@
 				494F59172098AA280075E7EE /* PlatformVersionConstraint.swift in Sources */,
 				498A894E2068FF5200457D66 /* TimelineFeature.swift in Sources */,
 				494F59492098ABE90075E7EE /* DefaultFeatureConstraintsEvaluator.swift in Sources */,
+				49B4DCC120F512D5006A6241 /* NSUserActivity+FlintAdditions.swift in Sources */,
 				49935BEC206D23E400CB2B5D /* LIFOArrayQueue.swift in Sources */,
 				496F8FDA203EEBDA003AB29B /* FlintAppInfo.swift in Sources */,
 				49F6824620D2C0B200B02318 /* ActivityMetadataRepresentable.swift in Sources */,
@@ -2050,6 +2065,7 @@
 				49935BF1206D250400CB2B5D /* TimeOrderedResultsController.swift in Sources */,
 				496F8F91203EEBBB003AB29B /* StoreKitPurchaseTracker.swift in Sources */,
 				49F6824120D2C07100B02318 /* ActivityMetadataBuilder.swift in Sources */,
+				49CF4D3B20F5281C0009FFF4 /* FlintLoggable.swift in Sources */,
 				496136E02099028F00291885 /* LocationUsage.swift in Sources */,
 				496F8F90203EEBBB003AB29B /* DefaultAvailabilityChecker.swift in Sources */,
 				496F8FB8203EEBD4003AB29B /* URLMappingsBuilder.swift in Sources */,
@@ -2153,6 +2169,7 @@
 				496F8F96203EEBBC003AB29B /* UserFeatureToggles.swift in Sources */,
 				496F8FF1203EEBDB003AB29B /* ActionStackEntry.swift in Sources */,
 				494F59182098AA280075E7EE /* PlatformVersionConstraint.swift in Sources */,
+				49B4DCC220F512D5006A6241 /* NSUserActivity+FlintAdditions.swift in Sources */,
 				498F97672077824200209633 /* FocusSelection.swift in Sources */,
 				49DFB7C820A2DF8500D3AE68 /* AuthorisationController.swift in Sources */,
 				49F6824720D2C0B200B02318 /* ActivityMetadataRepresentable.swift in Sources */,
@@ -2226,6 +2243,7 @@
 				496F8FBC203EEBD4003AB29B /* RouteParametersCodable.swift in Sources */,
 				496F8F49203EEB0F003AB29B /* String+Extensions.swift in Sources */,
 				49F6824220D2C07100B02318 /* ActivityMetadataBuilder.swift in Sources */,
+				49CF4D3C20F5281C0009FFF4 /* FlintLoggable.swift in Sources */,
 				49BC1C4820795E9E00A7FC77 /* LIFOArrayQueueDataSource.swift in Sources */,
 				49298244205FCC6000267A49 /* ActionOutcome.swift in Sources */,
 				49DFB7D720A2E00500D3AE68 /* SystemPermissionRequestAction.swift in Sources */,
@@ -2322,6 +2340,7 @@
 				49F37A3E209B2AC900B27671 /* PlatformConstraint.swift in Sources */,
 				49DB92432073C67900F758DC /* PurchaseRequirement.swift in Sources */,
 				4921AC0B20371B83003465E5 /* TopicPath.swift in Sources */,
+				49B4DCBF20F512D5006A6241 /* NSUserActivity+FlintAdditions.swift in Sources */,
 				4946FAC5208E23740097E10E /* ActionPerformOutcome.swift in Sources */,
 				498F97692077832F00209633 /* DefaultFocusSelection.swift in Sources */,
 				49F6824420D2C0B200B02318 /* ActivityMetadataRepresentable.swift in Sources */,
@@ -2395,6 +2414,7 @@
 				4976923B201F3CBE00F97BD5 /* URLMappingsBuilder.swift in Sources */,
 				49F6823F20D2C07100B02318 /* ActivityMetadataBuilder.swift in Sources */,
 				496136C5209900E200291885 /* CameraPermissionAdapter.swift in Sources */,
+				49CF4D3920F5281C0009FFF4 /* FlintLoggable.swift in Sources */,
 				495FD9FE200363290007A427 /* FeaturePath.swift in Sources */,
 				49647D372037434B005F9825 /* StoreKitPurchaseTracker.swift in Sources */,
 				49BC1C5720867C2400A7FC77 /* ActionStack.swift in Sources */,

--- a/FlintCore/Actions/Action.swift
+++ b/FlintCore/Actions/Action.swift
@@ -30,7 +30,7 @@ public protocol Action {
     /// are declared as `InputType?` so actions must always be ready to accept nil.
     ///
     /// - see: `NoInput`
-    associatedtype InputType: CustomStringConvertible = NoInput
+    associatedtype InputType: FlintLoggable = NoInput
 
     /// The type to use as the presenter (UI) for the action.
     ///

--- a/FlintCore/Actions/ActionContext.swift
+++ b/FlintCore/Actions/ActionContext.swift
@@ -12,7 +12,7 @@ import Foundation
 ///
 /// The context can be passed forward, or a new instance derived with new state, so that e.g. a subsystem can be
 /// passed the logger and state information as a single opaque value, without passing forward the entire action request
-public class ActionContext<InputType> where InputType: CustomStringConvertible {
+public class ActionContext<InputType> where InputType: FlintLoggable {
 
     /// Provides access to the context specific loggers for this action invocation
     public class Logs {

--- a/FlintCore/Actions/FlintLoggable.swift
+++ b/FlintCore/Actions/FlintLoggable.swift
@@ -7,18 +7,25 @@
 //
 import Foundation
 
-// The protocol to which Inputs must conform to be logged usefully by Flint's logging, Timeline, Action Stacks etc.
+/// The protocol to which Inputs must conform to be logged usefully by Flint's logging, Timeline, Action Stacks etc.
+///
+/// Flint requires a human readable description of all inputs to use in logs and debug UI, as well as a structured
+/// data representation for use in machine-readable outputs.
+///
+/// We cannot rely on `CustomStringConvertible` and `CustomDebugStringConvertible` for this as the developer may
+/// not control the contents of these, and the semantics are not rigid enough for our use.
 public protocol FlintLoggable {
-    /// Should return a human-readable description the type
+    /// Must return a human-readable description the type for use in logs and debug UI
     var loggingDescription: String { get }
     
-    /// Should return a machine-readable set of properties describing the type, for use in exported reports for
+    /// Must return a machine-readable set of properties describing the type, for use in exported reports for
     /// later structure analysis or querying.
     /// !!! TODO: How should we handle this in terms of performance, memory and nesting?
     /// Just a flat chunk of data for now
     var loggingInfo: [String:String]? { get }
 }
 
+/// Add defaults that use `CustomStringConvertible` and `CustomDebugStringConvertible`, to ease adoption.
 extension FlintLoggable {
     /// By default use `debugDescription` if it is supported, if not fall back to debug description.
     /// It is much better to provide a meaningful implementation on your own types
@@ -36,6 +43,62 @@ extension FlintLoggable {
 
 // Apply the default implementation to standard types from the runtime
 
-extension URL: FlintLoggable { }
-extension Int: FlintLoggable { }
-extension Double: FlintLoggable { }
+extension URL: FlintLoggable {
+    public var loggingInfo: [String:String]? {
+        return ["url": absoluteString]
+    }
+}
+
+extension Int: FlintLoggable {
+    public var loggingInfo: [String:String]? {
+        return ["value": description]
+    }
+}
+
+extension UInt: FlintLoggable {
+    public var loggingInfo: [String:String]? {
+        return ["value": description]
+    }
+}
+
+extension Float: FlintLoggable {
+    public var loggingInfo: [String:String]? {
+        return ["value": description]
+    }
+}
+
+extension Double: FlintLoggable {
+    public var loggingInfo: [String:String]? {
+        return ["value": description]
+    }
+}
+
+extension String: FlintLoggable {
+    public var loggingDescription: String {
+        return self
+    }
+
+    public var loggingInfo: [String:String]? {
+        return ["value": description]
+    }
+}
+
+// Apply proxying implementation to Optionals
+
+extension Optional: FlintLoggable where Wrapped: FlintLoggable {
+    public var loggingDescription: String {
+        if case let .some(value) = self {
+            return value.loggingDescription
+        } else {
+            return "nil"
+        }
+    }
+    public var loggingInfo: [String:String]? {
+        if case let .some(value) = self {
+            return value.loggingInfo
+        } else {
+            return nil
+        }
+    }
+}
+

--- a/FlintCore/Actions/FlintLoggable.swift
+++ b/FlintCore/Actions/FlintLoggable.swift
@@ -1,0 +1,41 @@
+//
+//  FlintLoggable.swift
+//  FlintCore
+//
+//  Created by Marc Palmer on 10/07/2018.
+//  Copyright © 2018 Montana Floss Co. Ltd. All rights reserved.
+//
+import Foundation
+
+// The protocol to which Inputs must conform to be logged usefully by Flint's logging, Timeline, Action Stacks etc.
+public protocol FlintLoggable {
+    /// Should return a human-readable description the type
+    var loggingDescription: String { get }
+    
+    /// Should return a machine-readable set of properties describing the type, for use in exported reports for
+    /// later structure analysis or querying.
+    /// !!! TODO: How should we handle this in terms of performance, memory and nesting?
+    /// Just a flat chunk of data for now
+    var loggingInfo: [String:String]? { get }
+}
+
+extension FlintLoggable {
+    /// By default use `debugDescription` if it is supported, if not fall back to debug description.
+    /// It is much better to provide a meaningful implementation on your own types
+    public var loggingDescription: String {
+        if let debugSelf = self as? CustomDebugStringConvertible {
+            return debugSelf.debugDescription
+        } else {
+            return String(reflecting: self)
+        }
+    }
+    public var loggingInfo: [String:String]? {
+        return ["loggingDescription": loggingDescription]
+    }
+}
+
+// Apply the default implementation to standard types from the runtime
+
+extension URL: FlintLoggable { }
+extension Int: FlintLoggable { }
+extension Double: FlintLoggable { }

--- a/FlintCore/Actions/NoInput.swift
+++ b/FlintCore/Actions/NoInput.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// A "null" state type for actions that do not require state
-public struct NoInput: RouteParametersCodable, ActivityCodable, CustomStringConvertible, CustomDebugStringConvertible {
+public struct NoInput: RouteParametersCodable, ActivityCodable, FlintLoggable {
     /// Currently we're using this because we cannot typealias action's InputType to be an optional,
     /// as this breaks generic constraints on URL mapping code. Optional (enum) cannot be used as a generic constraint
     public static let none = NoInput()
@@ -32,11 +32,11 @@ public struct NoInput: RouteParametersCodable, ActivityCodable, CustomStringConv
     
     public var requiredUserInfoKeys: Set<String> = []
     
-    public var description: String {
+    public var loggingDescription: String {
         return ""
     }
 
-    public var debugDescription: String {
-        return ""
+    public var loggingInfo: [String : Any]? {
+        return nil
     }
 }

--- a/FlintCore/Activities/NSUserActivity+FlintAdditions.swift
+++ b/FlintCore/Activities/NSUserActivity+FlintAdditions.swift
@@ -1,0 +1,11 @@
+//
+//  NSUserActivity+FlintAdditions.swift
+//  FlintCore
+//
+//  Created by Marc Palmer on 10/07/2018.
+//  Copyright © 2018 Montana Floss Co. Ltd. All rights reserved.
+//
+
+import Foundation
+
+extension NSUserActivity: FlintLoggable { }

--- a/FlintCore/Activities/PublishActivityRequest.swift
+++ b/FlintCore/Activities/PublishActivityRequest.swift
@@ -9,18 +9,22 @@
 import Foundation
 
 /// The information required to publish
-struct PublishActivityRequest: CustomStringConvertible, CustomDebugStringConvertible {
+struct PublishActivityRequest: FlintLoggable {
     let actionName: String
     let feature: FeatureDefinition.Type
     let activityCreator: () -> NSUserActivity?
     let appLink: URL?
 
-    var description: String {
+    var loggingDescription: String {
         return "Action: \(actionName)"
     }
     
-    var debugDescription: String {
-        return "PublishActivityRequest for action: \(actionName) of feature \(feature). URL: \(appLink?.description ?? "nil")"
+    var loggingInfo: [String:Any]? {
+        return [
+            "action": actionName,
+            "feature": feature.description,
+            "url": appLink?.description ?? "nil"
+        ]
     }
 }
 

--- a/FlintCore/Constraints/Permissions/DefaultPermissionChecker.swift
+++ b/FlintCore/Constraints/Permissions/DefaultPermissionChecker.swift
@@ -72,7 +72,7 @@ public class DefaultPermissionChecker: SystemPermissionChecker, CustomDebugStrin
                     // We probably need to also verify there is actual camera hardware, e.g. WatchOS
                     add(adapter.createAdapters(for: permission))
                 } else {
-                    FlintInternal.logger?.warning("Permission \(permission) is not supported. Either the target platform does not implement it, or your target is not linking the framework required.")
+                    FlintInternal.logger?.warning("Permission \"\(permission)\" is not supported. Either the target platform does not implement it, or your target is not linking the framework required.")
                 }
             }
 

--- a/FlintCore/Core/ActionSession.swift
+++ b/FlintCore/Core/ActionSession.swift
@@ -174,7 +174,7 @@ public class ActionSession: CustomDebugStringConvertible {
             return LogEventContext(session: sessionID,
                                    activity: activitySequenceID,
                                    topicPath: TopicPath(actionBinding: staticBinding),
-                                   arguments: input.description,
+                                   arguments: input.loggingDescription,
                                    presenter: String(describing: presenter))
         }
         let actionRequest = ActionRequest(uniqueID: nextRequestID(),
@@ -275,7 +275,7 @@ public class ActionSession: CustomDebugStringConvertible {
             return LogEventContext(session: sessionID,
                                    activity: activitySequenceID,
                                    topicPath: actionBinding.logTopicPath,
-                                   arguments: input.description,
+                                   arguments: input.loggingDescription,
                                    presenter: String(describing: presenter))
         }
         let request: ActionRequest<FeatureType, ActionType> = ActionRequest(uniqueID: nextRequestID(),

--- a/FlintCore/Debug Reporting/InternalJSONFormatting.swift
+++ b/FlintCore/Debug Reporting/InternalJSONFormatting.swift
@@ -61,7 +61,7 @@ extension TimelineEntry {
             "session": sessionName,
             "feature": feature.identifier.description,
             "action": actionName,
-            "input": inputDebugDescription
+            "input": inputInfo
         ]
     }
 }

--- a/FlintCore/Focus/FocusArea.swift
+++ b/FlintCore/Focus/FocusArea.swift
@@ -13,7 +13,7 @@ import Foundation
 /// This is an immutable wrapper used to allow the Focus feature to be used with either TopicPath or Feature.
 ///
 /// - see: `FocusFeature`
-public struct FocusArea: CustomStringConvertible, CustomDebugStringConvertible, Hashable {
+public struct FocusArea: FlintLoggable, CustomStringConvertible, CustomDebugStringConvertible, Hashable {
     public let topicPath: TopicPath
     
     public init(topicPath: TopicPath) {

--- a/FlintCore/Timeline/Timeline.swift
+++ b/FlintCore/Timeline/Timeline.swift
@@ -50,8 +50,8 @@ public class Timeline: ActionDispatchObserver, DebugReportable {
                                   sessionName: request.sessionName,
                                   feature: request.actionBinding.feature,
                                   actionName: request.actionBinding.action.name,
-                                  inputDescription: request.context.input.description,
-                                  inputDebugDescription: String(reflecting: request.context.input))
+                                  inputDescription: request.context.input.loggingDescription,
+                                  inputInfo: request.context.input.loggingInfo)
         entries.append(entry)
     }
     
@@ -69,8 +69,8 @@ public class Timeline: ActionDispatchObserver, DebugReportable {
                                   sessionName: request.sessionName,
                                   feature: request.actionBinding.feature,
                                   actionName: request.actionBinding.action.name,
-                                  inputDescription: request.context.input.description,
-                                  inputDebugDescription: String(reflecting: request.context.input),
+                                  inputDescription: request.context.input.loggingDescription,
+                                  inputInfo: request.context.input.loggingInfo,
                                   outcome: outcome.simplifiedOutcome)
         entries.append(entry)
     }

--- a/FlintCore/Timeline/TimelineEntry.swift
+++ b/FlintCore/Timeline/TimelineEntry.swift
@@ -53,20 +53,20 @@ import Foundation
     public let inputDescription: String?
     
     /// The detailed debug description of the input to the action
-    public let inputDebugDescription: String?
+    public let inputInfo: [String:Any]?
 
     /// The outcome of the action. This is nil unless `kind` is `.complete`.
     public let outcome: ActionOutcome?
 
-    convenience init(sequenceID: UInt, userInitiated: Bool, source: ActionSource, date: Date, sessionName: String, feature: FeatureDefinition.Type, actionName: String, inputDescription: String?, inputDebugDescription: String?) {
-        self.init(kind: .begin, sequenceID: sequenceID, userInitiated: userInitiated, source: source, date: date, sessionName: sessionName, feature: feature, actionName: actionName, inputDescription: inputDescription, inputDebugDescription: inputDebugDescription, outcome: nil)
+    convenience init(sequenceID: UInt, userInitiated: Bool, source: ActionSource, date: Date, sessionName: String, feature: FeatureDefinition.Type, actionName: String, inputDescription: String?, inputInfo: [String:String]?) {
+        self.init(kind: .begin, sequenceID: sequenceID, userInitiated: userInitiated, source: source, date: date, sessionName: sessionName, feature: feature, actionName: actionName, inputDescription: inputDescription, inputInfo: inputInfo, outcome: nil)
     }
     
-    convenience init(sequenceID: UInt, userInitiated: Bool, source: ActionSource, date: Date, sessionName: String, feature: FeatureDefinition.Type, actionName: String, inputDescription: String?, inputDebugDescription: String?, outcome: ActionOutcome) {
-        self.init(kind: .complete, sequenceID: sequenceID, userInitiated: userInitiated, source: source, date: date, sessionName: sessionName, feature: feature, actionName: actionName, inputDescription: inputDescription, inputDebugDescription: inputDebugDescription, outcome: outcome)
+    convenience init(sequenceID: UInt, userInitiated: Bool, source: ActionSource, date: Date, sessionName: String, feature: FeatureDefinition.Type, actionName: String, inputDescription: String?, inputInfo: [String:String]?, outcome: ActionOutcome) {
+        self.init(kind: .complete, sequenceID: sequenceID, userInitiated: userInitiated, source: source, date: date, sessionName: sessionName, feature: feature, actionName: actionName, inputDescription: inputDescription, inputInfo: inputInfo, outcome: outcome)
     }
     
-    private init(kind: Kind, sequenceID: UInt, userInitiated: Bool, source: ActionSource, date: Date, sessionName: String, feature: FeatureDefinition.Type, actionName: String, inputDescription: String?, inputDebugDescription: String?, outcome: ActionOutcome?) {
+    private init(kind: Kind, sequenceID: UInt, userInitiated: Bool, source: ActionSource, date: Date, sessionName: String, feature: FeatureDefinition.Type, actionName: String, inputDescription: String?, inputInfo: [String:String]?, outcome: ActionOutcome?) {
         self.userInitiated = userInitiated
         self.source = source
         self.kind = kind
@@ -76,7 +76,7 @@ import Foundation
         self.feature = feature
         self.actionName = actionName
         self.inputDescription = inputDescription
-        self.inputDebugDescription = inputDebugDescription
+        self.inputInfo = inputInfo
         self.outcome = outcome
     }
     

--- a/FlintUI.xcodeproj/project.pbxproj
+++ b/FlintUI.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		49BC1C552086473E00A7FC77 /* FeatureBrowserFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49BC1C542086473E00A7FC77 /* FeatureBrowserFeature.swift */; };
 		49BC1C5C20874F0000A7FC77 /* ActionStackActionViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49BC1C5B20874F0000A7FC77 /* ActionStackActionViewController.swift */; };
 		49BC1C5E2087551500A7FC77 /* ActionStackViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49BC1C5D2087551400A7FC77 /* ActionStackViewController.swift */; };
+		49CF4D3F20F601450009FFF4 /* FakeFeatures.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49CF4D3E20F601450009FFF4 /* FakeFeatures.swift */; };
 		49D5796B20618AD9006EE0C9 /* ActionDetailViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D5796A20618AD9006EE0C9 /* ActionDetailViewController.swift */; };
 		49D579702063C6E0006EE0C9 /* FeatureBrowserViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D5796F2063C6E0006EE0C9 /* FeatureBrowserViewController.swift */; };
 		49DB9233206FD67C00F758DC /* FocusLogViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB9230206FD65B00F758DC /* FocusLogViewController.swift */; };
@@ -108,6 +109,7 @@
 		49BC1C542086473E00A7FC77 /* FeatureBrowserFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureBrowserFeature.swift; sourceTree = "<group>"; };
 		49BC1C5B20874F0000A7FC77 /* ActionStackActionViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActionStackActionViewController.swift; sourceTree = "<group>"; };
 		49BC1C5D2087551400A7FC77 /* ActionStackViewController.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActionStackViewController.swift; sourceTree = "<group>"; };
+		49CF4D3E20F601450009FFF4 /* FakeFeatures.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FakeFeatures.swift; sourceTree = "<group>"; };
 		49D5796A20618AD9006EE0C9 /* ActionDetailViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionDetailViewController.swift; sourceTree = "<group>"; };
 		49D5796F2063C6E0006EE0C9 /* FeatureBrowserViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureBrowserViewController.swift; sourceTree = "<group>"; };
 		49DB9230206FD65B00F758DC /* FocusLogViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FocusLogViewController.swift; sourceTree = "<group>"; };
@@ -149,6 +151,7 @@
 		4904958B2060304B00A57991 /* FlintUISandbox */ = {
 			isa = PBXGroup;
 			children = (
+				49CF4D3D20F601260009FFF4 /* Features */,
 				4908956F208F47910022E0A7 /* Frameworks */,
 				4904958C2060304B00A57991 /* AppDelegate.swift */,
 				4904958E2060304B00A57991 /* ViewController.swift */,
@@ -259,6 +262,14 @@
 				49BC1C542086473E00A7FC77 /* FeatureBrowserFeature.swift */,
 			);
 			path = Features;
+			sourceTree = "<group>";
+		};
+		49CF4D3D20F601260009FFF4 /* Features */ = {
+			isa = PBXGroup;
+			children = (
+				49CF4D3E20F601450009FFF4 /* FakeFeatures.swift */,
+			);
+			name = Features;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -414,6 +425,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				4904958F2060304B00A57991 /* ViewController.swift in Sources */,
+				49CF4D3F20F601450009FFF4 /* FakeFeatures.swift in Sources */,
 				4904958D2060304B00A57991 /* AppDelegate.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;

--- a/FlintUI/iOS/View Controllers/TimelineEntryViewController.swift
+++ b/FlintUI/iOS/View Controllers/TimelineEntryViewController.swift
@@ -160,7 +160,11 @@ class TimelineEntryViewController: UITableViewController {
                 detail = String(reflecting: actionHistoryEntry.feature)
             case .input:
                 text = "Input"
-                detail = actionHistoryEntry.inputDebugDescription ?? "<none>"
+                if let info = actionHistoryEntry.inputInfo {
+                    detail = String(reflecting: info)
+                } else {
+                    detail = "No input"
+                }
             case .outcome:
                 if let outcome = actionHistoryEntry.outcome {
                     text = "Outcome"

--- a/FlintUISandbox/AppDelegate.swift
+++ b/FlintUISandbox/AppDelegate.swift
@@ -22,53 +22,6 @@ class FakePresentationRouter: PresentationRouter {
     }
 } 
 
-class FakeFeatures: FeatureGroup {
-    static var name = "MyFakeFeaturesAliased"
-    static var subfeatures: [FeatureDefinition.Type] = [FakeFeature.self]
-}
-
-final class FakeFeature: ConditionalFeature {
-    static var name = "FakeFeature1"
-    
-    static var description = "A fake feature"
-    
-    static let action1: ConditionalActionBinding<FakeFeature, DoSomethingFakeAction> = action(DoSomethingFakeAction.self)
-    
-    static func prepare(actions: FeatureActionsBuilder) {
-        actions.declare(action1)
-    }
-
-    static func constraints(requirements: FeatureConstraintsBuilder) {
-        requirements.iOSOnly = 10
-        requirements.permission(.camera)
-        requirements.permission(.photos)
-        requirements.permission(.contacts(entity: .contacts))
-        requirements.permission(.calendarEvents)
-        requirements.permission(.reminders)
-        requirements.permission(.motion)
-        requirements.permission(.speechRecognition)
-    }
-}
-
-final class DoSomethingFakeAction: Action {
-    typealias InputType = NoInput
-    typealias PresenterType = NoPresenter
-    
-    static var activityTypes: Set<ActivityEligibility> = [.handoff, .prediction]
-
-    static func prepareActivity(_ activity: ActivityBuilder<InputType>) {
-        activity.title = "Do a fake thing"
-        activity.subtitle = "This will show up in Siri shortcuts on iOS 12"
-        activity.requiredUserInfoKeys = ["fake"]
-        activity.userInfo["fake"] = true
-    }
-
-    static func perform(with context: ActionContext<InputType>, using presenter: PresenterType, completion: @escaping (ActionPerformOutcome) -> Void) {
-        context.logs.development?.info("Testing logs from fake feature")
-        completion(.success(closeActionStack: true))
-    }
-}
-
 @UIApplicationMain
 class AppDelegate: UIResponder, UIApplicationDelegate {
 

--- a/FlintUISandbox/AppDelegate.swift
+++ b/FlintUISandbox/AppDelegate.swift
@@ -42,7 +42,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         testTimer?.setEventHandler(handler: {
             print("Performing a fake action, this will show even if not in Focus")
             if let request = FakeFeature.action1.request() {
-                request.perform()
+                request.perform(with: nil)
             } else {
                 print("NOT Performing the fake action, permissions were not available")
             }

--- a/FlintUISandbox/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/FlintUISandbox/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -84,6 +84,11 @@
       "idiom" : "ipad",
       "size" : "83.5x83.5",
       "scale" : "2x"
+    },
+    {
+      "idiom" : "ios-marketing",
+      "size" : "1024x1024",
+      "scale" : "1x"
     }
   ],
   "info" : {

--- a/FlintUISandbox/FakeFeatures.swift
+++ b/FlintUISandbox/FakeFeatures.swift
@@ -14,12 +14,12 @@ class FakeFeatures: FeatureGroup {
     static var subfeatures: [FeatureDefinition.Type] = [FakeFeature.self]
 }
 
-final class FakeFeature: ConditionalFeature {
+final class FakeFeature: ConditionalFeature, URLMapped {
     static var name = "FakeFeature1"
     
     static var description = "A fake feature"
     
-    static let action1: ConditionalActionBinding<FakeFeature, DoSomethingFakeAction> = action(DoSomethingFakeAction.self)
+    static let action1 = action(DoSomethingFakeAction.self)
     
     static func prepare(actions: FeatureActionsBuilder) {
         actions.declare(action1)
@@ -31,10 +31,28 @@ final class FakeFeature: ConditionalFeature {
         requirements.permission(.photos)
         requirements.permission(.contacts(entity: .contacts))
     }
+    
+    static func urlMappings(routes: URLMappingsBuilder) {
+        routes.send("/*", to: action1)
+    }
+}
+
+extension String: RouteParametersCodable {
+    public init?(from routeParameters: RouteParameters?, mapping: URLMapping) {
+        guard let value = routeParameters?["value"] else {
+            return nil
+        }
+        self.init(value)
+    }
+    
+    public func encodeAsRouteParameters(for mapping: URLMapping) -> RouteParameters? {
+        return ["value": self]
+    }
+    
 }
 
 final class DoSomethingFakeAction: Action {
-    typealias InputType = NoInput
+    typealias InputType = String?
     typealias PresenterType = NoPresenter
     
     static var activityTypes: Set<ActivityEligibility> = [.handoff, .prediction]

--- a/FlintUISandbox/FakeFeatures.swift
+++ b/FlintUISandbox/FakeFeatures.swift
@@ -30,10 +30,6 @@ final class FakeFeature: ConditionalFeature {
         requirements.permission(.camera)
         requirements.permission(.photos)
         requirements.permission(.contacts(entity: .contacts))
-        requirements.permission(.calendarEvents)
-        requirements.permission(.reminders)
-        requirements.permission(.motion)
-        requirements.permission(.speechRecognition)
     }
 }
 

--- a/FlintUISandbox/FakeFeatures.swift
+++ b/FlintUISandbox/FakeFeatures.swift
@@ -1,0 +1,57 @@
+//
+//  FakeFeatures.swift
+//  FlintUISandbox
+//
+//  Created by Marc Palmer on 11/07/2018.
+//  Copyright © 2018 Montana Floss Co. Ltd. All rights reserved.
+//
+
+import Foundation
+import FlintCore
+
+class FakeFeatures: FeatureGroup {
+    static var name = "MyFakeFeaturesAliased"
+    static var subfeatures: [FeatureDefinition.Type] = [FakeFeature.self]
+}
+
+final class FakeFeature: ConditionalFeature {
+    static var name = "FakeFeature1"
+    
+    static var description = "A fake feature"
+    
+    static let action1: ConditionalActionBinding<FakeFeature, DoSomethingFakeAction> = action(DoSomethingFakeAction.self)
+    
+    static func prepare(actions: FeatureActionsBuilder) {
+        actions.declare(action1)
+    }
+
+    static func constraints(requirements: FeatureConstraintsBuilder) {
+        requirements.iOSOnly = 10
+        requirements.permission(.camera)
+        requirements.permission(.photos)
+        requirements.permission(.contacts(entity: .contacts))
+        requirements.permission(.calendarEvents)
+        requirements.permission(.reminders)
+        requirements.permission(.motion)
+        requirements.permission(.speechRecognition)
+    }
+}
+
+final class DoSomethingFakeAction: Action {
+    typealias InputType = NoInput
+    typealias PresenterType = NoPresenter
+    
+    static var activityTypes: Set<ActivityEligibility> = [.handoff, .prediction]
+
+    static func prepareActivity(_ activity: ActivityBuilder<InputType>) {
+        activity.title = "Do a fake thing"
+        activity.subtitle = "This will show up in Siri shortcuts on iOS 12"
+        activity.requiredUserInfoKeys = ["fake"]
+        activity.userInfo["fake"] = true
+    }
+
+    static func perform(with context: ActionContext<InputType>, using presenter: PresenterType, completion: @escaping (ActionPerformOutcome) -> Void) {
+        context.logs.development?.info("Testing logs from fake feature")
+        completion(.success(closeActionStack: true))
+    }
+}

--- a/FlintUISandbox/Info.plist
+++ b/FlintUISandbox/Info.plist
@@ -16,6 +16,19 @@
 	<string>APPL</string>
 	<key>CFBundleShortVersionString</key>
 	<string>1.0</string>
+	<key>CFBundleURLTypes</key>
+	<array>
+		<dict>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>CFBundleURLName</key>
+			<string>Main</string>
+			<key>CFBundleURLSchemes</key>
+			<array>
+				<string>flint-sandbox</string>
+			</array>
+		</dict>
+	</array>
 	<key>CFBundleVersion</key>
 	<string>1</string>
 	<key>LSRequiresIPhoneOS</key>


### PR DESCRIPTION
This addresses #139 with different naming.

I think this is pretty solid, in that we now no longer rely on `CustomStringConvertible` and `CustomDebugStringConvertible` which may not be under the developers control (think third party frameworks) and also may be used for other purposes in the app.

The goal for Flint is that we must be able to get a good human readable string for an input for use in logs, and we need structured data for machine-readable post mortem data, so the protocol has this:

```swift
public protocol FlintLoggable {
    var loggingDescription: String { get }
    var loggingInfo: [String:String]? { get }
```

An extension provides default implementations of these for all types, and specific implementations for standard runtime types.

What is left to establish is how hierarchical data should be represented in `loggingInfo`. It probably needs to change to have a different type for the values, perhaps FlintLoggable? However we have the quandary of how to capture this info in a lightweight way so that we don't store massive graphs of data in memory and have huge graphs of objects to log out / store.

Perhaps mandating String for values is enough here, such that all nested items must be rendered as a string? Hmm.

It is assumed that while persisting the information about an input type, Flint will add a `type` attribute to the output.

This PR has been updated to include another thing this unlocks - support for `InputType`s on Actions, that are `Optional`. This is achieved through conditional conformance to `FlintLoggable` on `Optional` where `Wrapped: FlintLoggable`. It will delegate to the wrapped value, so you don't get weird errors now if you specify `typealias InputType = Something?` with an optional type.