### PR TITLE
Change arguments on `perform` and related functions to clearer intent

### DIFF
--- a/FlintCore/Actions/Action.swift
+++ b/FlintCore/Actions/Action.swift
@@ -69,7 +69,7 @@ public protocol Action {
     /// The `completion` closure must be called when the action has been performed.
     ///
     /// - param context: The action's context, which includes the `input` and
-    static func perform(with context: ActionContext<InputType>, using presenter: PresenterType, completion: @escaping (ActionPerformOutcome) -> Void)
+    static func perform(context: ActionContext<InputType>, presenter: PresenterType, completion: @escaping (ActionPerformOutcome) -> Void)
 
     // The stuff that follows should be in a separate protocol but requires InputType so it is not possible to do this
     // in Swift 4, as we need the InputType typealias, but then there is no way to constrain the ActionDispatchObserver functions

--- a/FlintCore/Actions/ActionContext.swift
+++ b/FlintCore/Actions/ActionContext.swift
@@ -40,21 +40,21 @@ public class ActionContext<InputType> where InputType: FlintLoggable {
     /// Perform the action in the same session as this current action request, passing on the contextual loggers
     /// Use this to perform other actions within action implementations.
     public func perform<FeatureType, ActionType>(_ actionBinding: StaticActionBinding<FeatureType, ActionType>,
-                           using presenter: ActionType.PresenterType,
-                           with input: ActionType.InputType,
+                           input: ActionType.InputType,
+                           presenter: ActionType.PresenterType,
                            userInitiated: Bool,
                            completion: ((ActionOutcome) -> ())? = nil) {
-        session.perform(actionBinding, using: presenter, with: input, userInitiated: userInitiated, source: source, completion: completion)
+        session.perform(actionBinding, input: input, presenter: presenter, userInitiated: userInitiated, source: source, completion: completion)
     }
     
     /// Perform the action in the same session as this current action request, passing on the contextual loggers
     /// Use this to perform other actions within action implementations.
     public func perform<FeatureType, ActionType>(_ conditionalRequest: ConditionalActionRequest<FeatureType, ActionType>,
-                           using presenter: ActionType.PresenterType,
-                           with input: ActionType.InputType,
+                           input: ActionType.InputType,
+                           presenter: ActionType.PresenterType,
                            userInitiated: Bool,
                            completion: ((ActionOutcome) -> ())? = nil) {
-        session.perform(conditionalRequest, using: presenter, with: input, userInitiated: userInitiated, source: source, completion: completion)
+        session.perform(conditionalRequest, input: input, presenter: presenter, userInitiated: userInitiated, source: source, completion: completion)
     }
 
     public var debugDescriptionOfInput: String? {

--- a/FlintCore/Actions/StaticActionBinding.swift
+++ b/FlintCore/Actions/StaticActionBinding.swift
@@ -28,6 +28,8 @@ import Foundation
 /// ... later you can perform the action directly ...
 ///
 /// DocumentManagementFeature.createNew.perform( ... )
+///
+/// Note that you do not create these bindings explicitly, you must use the Flint `action` function for this.
 /// ```
 public struct StaticActionBinding<FeatureType, ActionType>: CustomDebugStringConvertible where FeatureType: FeatureDefinition, ActionType: Action {
 
@@ -63,10 +65,9 @@ public struct StaticActionBinding<FeatureType, ActionType>: CustomDebugStringCon
     /// - param presenter: The object presenting the outcome of the action
     /// - param input: The value to pass as the input of the action
     /// - param completion: The completion handler to call.
-    public func perform(using presenter: ActionType.PresenterType,
-                           with input: ActionType.InputType,
-                           completion: ((ActionOutcome) -> ())? = nil) {
-        ActionSession.main.perform(self, using: presenter, with: input, completion: completion)
+    public func perform(input: ActionType.InputType, presenter: ActionType.PresenterType,
+                        completion: ((ActionOutcome) -> ())? = nil) {
+        ActionSession.main.perform(self, input: input, presenter: presenter, completion: completion)
     }
 
     /// A convenience function to perform the action in the main `ActionSession`
@@ -78,12 +79,11 @@ public struct StaticActionBinding<FeatureType, ActionType>: CustomDebugStringCon
     /// - param userInitiated: Set to `true` if the user explicitly chose to perform this action, `false` if not
     /// - param source: Indicates where the request came from
     /// - param completion: The completion handler to call.
-    public func perform(using presenter: ActionType.PresenterType,
-                           with input: ActionType.InputType,
-                           userInitiated: Bool,
-                           source: ActionSource,
-                           completion: ((ActionOutcome) -> ())? = nil) {
-        ActionSession.main.perform(self, using: presenter, with: input, userInitiated: userInitiated, source: source, completion: completion)
+    public func perform(input: ActionType.InputType, presenter: ActionType.PresenterType,
+                        userInitiated: Bool,
+                        source: ActionSource,
+                        completion: ((ActionOutcome) -> ())? = nil) {
+        ActionSession.main.perform(self, input: input, presenter: presenter, userInitiated: userInitiated, source: source, completion: completion)
     }
 
     /// Convenience function for creating an activity for this action with a given input.
@@ -95,43 +95,45 @@ public struct StaticActionBinding<FeatureType, ActionType>: CustomDebugStringCon
     }
 }
 
+/// Overloads for the case where there is no presenter
 extension StaticActionBinding where ActionType.PresenterType == NoPresenter {
-    public func perform(with input: ActionType.InputType,
+    public func perform(input: ActionType.InputType,
                         completion: ((ActionOutcome) -> ())? = nil) {
-        ActionSession.main.perform(self, using: NoPresenter(), with: input, completion: completion)
+        ActionSession.main.perform(self, input: input, presenter: NoPresenter(), completion: completion)
     }
 
-    public func perform(with input: ActionType.InputType,
+    public func perform(input: ActionType.InputType,
                         userInitiated: Bool,
                         source: ActionSource,
                         completion: ((ActionOutcome) -> ())? = nil) {
-        ActionSession.main.perform(self, using: NoPresenter(), with: input, userInitiated: userInitiated, source: source, completion: completion)
+        ActionSession.main.perform(self, input: input, presenter: NoPresenter(), userInitiated: userInitiated, source: source, completion: completion)
     }
 }
 
+/// Overloads for the case where there is no input
 extension StaticActionBinding where ActionType.InputType == NoInput {
-    public func perform(using presenter: ActionType.PresenterType,
+    public func perform(presenter: ActionType.PresenterType,
                         completion: ((ActionOutcome) -> ())? = nil) {
-        ActionSession.main.perform(self, using: presenter, with: NoInput.none, completion: completion)
+        ActionSession.main.perform(self, input: NoInput.none, presenter: presenter, completion: completion)
     }
 
-    public func perform(using presenter: ActionType.PresenterType,
+    public func perform(presenter: ActionType.PresenterType,
                         userInitiated: Bool,
                         source: ActionSource,
                         completion: ((ActionOutcome) -> ())? = nil) {
-        ActionSession.main.perform(self, using: presenter, with: NoInput.none, userInitiated: userInitiated, source: source, completion: completion)
+        ActionSession.main.perform(self, input: NoInput.none, presenter: presenter, userInitiated: userInitiated, source: source, completion: completion)
     }
 }
 
-
+/// Overloads for the case where there is neither a presenter nor an input
 extension StaticActionBinding where ActionType.InputType == NoInput, ActionType.PresenterType == NoPresenter {
     public func perform(completion: ((ActionOutcome) -> ())? = nil) {
-        ActionSession.main.perform(self, using: NoPresenter(), with: NoInput.none, completion: completion)
+        ActionSession.main.perform(self, input: .none, presenter: NoPresenter(), completion: completion)
     }
 
     public func perform(userInitiated: Bool,
                         source: ActionSource,
                         completion: ((ActionOutcome) -> ())? = nil) {
-        ActionSession.main.perform(self, using: NoPresenter(), with: NoInput.none, userInitiated: userInitiated, source: source, completion: completion)
+        ActionSession.main.perform(self, input: NoInput.none, presenter: NoPresenter(), userInitiated: userInitiated, source: source, completion: completion)
     }
 }

--- a/FlintCore/Activities/ActionActivityMappings.swift
+++ b/FlintCore/Activities/ActionActivityMappings.swift
@@ -101,14 +101,14 @@ class ActionActivityMappings {
             }
       
             do {
-                let state = try ActionType.InputType.init(activityUserInfo: activity.userInfo)
+                let input = try ActionType.InputType.init(activityUserInfo: activity.userInfo)
 
-                let presentationRouterResult = presentationRouter.presentation(for: binding, with: state)
+                let presentationRouterResult = presentationRouter.presentation(for: binding, with: input)
 
-                FlintInternal.urlMappingLogger?.debug("Activity executor presentation \(presentationRouterResult) received for \(binding) with state \(state)")
+                FlintInternal.urlMappingLogger?.debug("Activity executor presentation \(presentationRouterResult) received for \(binding) with state \(input)")
                 switch presentationRouterResult {
                     case .appReady(let presenter):
-                        binding.perform(using: presenter, with: state, userInitiated: true, source: source)
+                        binding.perform(input: input, presenter: presenter, userInitiated: true, source: source)
                     case .unsupported:
                         FlintInternal.urlMappingLogger?.error("No presentation for activity ID \(activity.activityType) for \(binding) - received .unsupported")
                     case .appCancelled, .userCancelled, .appPerformed:
@@ -150,7 +150,7 @@ class ActionActivityMappings {
                 switch presentationRouterResult {
                     case .appReady(let presenter):
                         if let request = binding.request() {
-                            request.perform(using: presenter, with: state, userInitiated: true, source: source)
+                            request.perform(input: state, presenter: presenter, userInitiated: true, source: source)
                         }
                     case .unsupported:
                         FlintInternal.urlMappingLogger?.error("No presentation for activity ID \(activity.activityType) for \(binding) - received .unsupported")

--- a/FlintCore/Activities/ActionActivityMappings.swift
+++ b/FlintCore/Activities/ActionActivityMappings.swift
@@ -103,7 +103,7 @@ class ActionActivityMappings {
             do {
                 let input = try ActionType.InputType.init(activityUserInfo: activity.userInfo)
 
-                let presentationRouterResult = presentationRouter.presentation(for: binding, with: input)
+                let presentationRouterResult = presentationRouter.presentation(for: binding, input: input)
 
                 FlintInternal.urlMappingLogger?.debug("Activity executor presentation \(presentationRouterResult) received for \(binding) with state \(input)")
                 switch presentationRouterResult {
@@ -144,7 +144,7 @@ class ActionActivityMappings {
             do {
                 let state = try ActionType.InputType.init(activityUserInfo: activity.userInfo)
 
-                let presentationRouterResult = presentationRouter.presentation(for: binding, with: state)
+                let presentationRouterResult = presentationRouter.presentation(for: binding, input: state)
 
                 FlintInternal.urlMappingLogger?.debug("Activity executor presentation \(presentationRouterResult) received for \(binding) with state \(state)")
                 switch presentationRouterResult {

--- a/FlintCore/Activities/ActivityActionDispatchObserver.swift
+++ b/FlintCore/Activities/ActivityActionDispatchObserver.swift
@@ -86,7 +86,7 @@ public class ActivityActionDispatchObserver: ActionDispatchObserver {
                                                 activityCreator: prepareActivityWrapper,
                                                 appLink: appLink)
         DispatchQueue.main.async {
-            publishRequest.perform(using: NoPresenter(), with: publishState, userInitiated: false, source: .application)
+            publishRequest.perform(input: publishState, presenter: NoPresenter(), userInitiated: false, source: .application)
         }
     }
 }

--- a/FlintCore/Activities/HandleActivityAction.swift
+++ b/FlintCore/Activities/HandleActivityAction.swift
@@ -34,7 +34,7 @@ final class HandleActivityAction: Action {
             context.logs.development?.debug("Auto URL found: \(autoURL)")
             if let request = RoutesFeature.request(RoutesFeature.performIncomingURL) {
                 var result: ActionPerformOutcome = .failure(error: nil, closeActionStack: true)
-                request.perform(using: presenter, with: autoURL, userInitiated: true, source: context.source) { outcome in
+                request.perform(input: autoURL, presenter: presenter, userInitiated: true, source: context.source) { outcome in
                     context.logs.development?.debug("Auto URL perform completed: \(outcome)")
                     if case .success = outcome {
                         result = .success(closeActionStack: true)
@@ -50,7 +50,7 @@ final class HandleActivityAction: Action {
         } else {
             if let request = ActivitiesFeature.request(ActivitiesFeature.performIncomingActivity) {
                 var result: ActionPerformOutcome = .failure(error: nil, closeActionStack: true)
-                request.perform(using: presenter, with: context.input, userInitiated: true, source: context.source) { outcome in
+                request.perform(input: context.input, presenter: presenter, userInitiated: true, source: context.source) { outcome in
                     context.logs.development?.debug("userInfo perform completed: \(outcome)")
                     if case .success = outcome {
                         result = .success(closeActionStack: true)

--- a/FlintCore/Activities/HandleActivityAction.swift
+++ b/FlintCore/Activities/HandleActivityAction.swift
@@ -27,7 +27,7 @@ final class HandleActivityAction: Action {
     
     static let description: String = "Automatic action dispatch for incoming NSUserActivity instances published by Flint"
     
-    static func perform(with context: ActionContext<NSUserActivity>, using presenter: PresentationRouter, completion: @escaping (ActionPerformOutcome) -> Void) {
+    static func perform(context: ActionContext<NSUserActivity>, presenter: PresentationRouter, completion: @escaping (ActionPerformOutcome) -> Void) {
         // Do we need to check if activityType == CSSearchableItemActionType for spotlight invocations?
         
         if let autoURL = context.input.userInfo?[ActivitiesFeature.autoURLUserInfoKey] as? URL {

--- a/FlintCore/Activities/PerformIncomingActivityAction.swift
+++ b/FlintCore/Activities/PerformIncomingActivityAction.swift
@@ -22,7 +22,7 @@ final public class PerformIncomingActivityAction: Action {
     ///
     /// The completion outcome will fail with error `noURLMappingFound` if the URL does not map to anything
     /// that Flint knows about.
-    public static func perform(with context: ActionContext<NSUserActivity>, using presenter: PresentationRouter, completion: @escaping (ActionPerformOutcome) -> Void) {
+    public static func perform(context: ActionContext<NSUserActivity>, presenter: PresentationRouter, completion: @escaping (ActionPerformOutcome) -> Void) {
         context.logs.development?.debug("Finding action executor for activity: \(context.input.activityType), userInfo \(String(describing: context.input.userInfo))")
         
         if let executor = ActionActivityMappings.instance.actionExecutor(for: context.input.activityType) {

--- a/FlintCore/Activities/PublishCurrentActionActivityAction.swift
+++ b/FlintCore/Activities/PublishCurrentActionActivityAction.swift
@@ -33,7 +33,7 @@ final class PublishCurrentActionActivityAction: Action {
         }
     }
 
-    static func perform(with context: ActionContext<InputType>, using presenter: NoPresenter, completion: @escaping (ActionPerformOutcome) -> Void) {
+    static func perform(context: ActionContext<InputType>, presenter: NoPresenter, completion: @escaping (ActionPerformOutcome) -> Void) {
         if let activity = context.input.activityCreator() {
             var activityDebug: String = ""
             if let _ = context.logs.development?.debug {

--- a/FlintCore/Conditional Features/ConditionalActionBinding.swift
+++ b/FlintCore/Conditional Features/ConditionalActionBinding.swift
@@ -34,7 +34,7 @@ import Foundation
 ///
 /// if let request = TimelineFeature.loadData.request() {
 ///     // Perform it in the main session. Use `ActionSession.perform` to use other sessions.
-///     request.perform(using: presenter, with: input)
+///     request.perform(input: input, presenter: presenter)
 /// } else {
 ///     fatalError("Should not have been able to chose this action, feature is disabled!")
 /// }

--- a/FlintCore/Conditional Features/ConditionalActionRequest.swift
+++ b/FlintCore/Conditional Features/ConditionalActionRequest.swift
@@ -23,57 +23,60 @@ public struct ConditionalActionRequest<FeatureType, ActionType> where FeatureTyp
         self.actionBinding = actionBinding
     }
 
-    public func perform(using presenter: ActionType.PresenterType,
-                       with input: ActionType.InputType,
-                       completion: ((ActionOutcome) -> ())? = nil) {
-        ActionSession.main.perform(self, using: presenter, with: input, completion: completion)
+    public func perform(input: ActionType.InputType,
+                        presenter: ActionType.PresenterType,
+                        completion: ((ActionOutcome) -> ())? = nil) {
+        ActionSession.main.perform(self, input: input, presenter: presenter, completion: completion)
     }
     
-    public func perform(using presenter: ActionType.PresenterType,
-                       with input: ActionType.InputType,
-                       userInitiated: Bool,
-                       source: ActionSource = .application,
-                       completion: ((ActionOutcome) -> ())? = nil) {
-        ActionSession.main.perform(self, using: presenter, with: input, userInitiated: userInitiated, source: source, completion: completion)
+    public func perform(input: ActionType.InputType,
+                        presenter: ActionType.PresenterType,
+                        userInitiated: Bool,
+                        source: ActionSource = .application,
+                        completion: ((ActionOutcome) -> ())? = nil) {
+        ActionSession.main.perform(self, input: input, presenter: presenter, userInitiated: userInitiated, source: source, completion: completion)
     }
 }
 
+/// Overloads for actions with no presenter
 extension ConditionalActionRequest where ActionType.PresenterType == NoPresenter {
-    public func perform(with input: ActionType.InputType,
+    public func perform(input: ActionType.InputType,
                         completion: ((ActionOutcome) -> ())? = nil) {
-        ActionSession.main.perform(self, using: NoPresenter(), with: input, completion: completion)
+        ActionSession.main.perform(self, input: input, presenter: NoPresenter(), completion: completion)
     }
 
-    public func perform(with input: ActionType.InputType,
+    public func perform(input: ActionType.InputType,
                         userInitiated: Bool,
                         source: ActionSource,
                         completion: ((ActionOutcome) -> ())? = nil) {
-        ActionSession.main.perform(self, using: NoPresenter(), with: input, userInitiated: userInitiated, source: source, completion: completion)
+        ActionSession.main.perform(self, input: input, presenter: NoPresenter(), userInitiated: userInitiated, source: source, completion: completion)
     }
 }
 
+/// Overloads for actions with no input
 extension ConditionalActionRequest where ActionType.InputType == NoInput {
-    public func perform(using presenter: ActionType.PresenterType,
+    public func perform(presenter: ActionType.PresenterType,
                         completion: ((ActionOutcome) -> ())? = nil) {
-        ActionSession.main.perform(self, using: presenter, with: NoInput.none, completion: completion)
+        ActionSession.main.perform(self, input: .none, presenter: presenter, completion: completion)
     }
 
-    public func perform(using presenter: ActionType.PresenterType,
+    public func perform(presenter: ActionType.PresenterType,
                         userInitiated: Bool,
                         source: ActionSource,
                         completion: ((ActionOutcome) -> ())? = nil) {
-        ActionSession.main.perform(self, using: presenter, with: NoInput.none, userInitiated: userInitiated, source: source, completion: completion)
+        ActionSession.main.perform(self, input: .none, presenter: presenter, userInitiated: userInitiated, source: source, completion: completion)
     }
 }
 
+/// Overloads for actions with neither input nor presenter
 extension ConditionalActionRequest where ActionType.InputType == NoInput, ActionType.PresenterType == NoPresenter {
     public func perform(completion: ((ActionOutcome) -> ())? = nil) {
-        ActionSession.main.perform(self, using: NoPresenter(), with: NoInput.none, completion: completion)
+        ActionSession.main.perform(self, input: .none, presenter: NoPresenter(), completion: completion)
     }
 
     public func perform(userInitiated: Bool,
                         source: ActionSource,
                         completion: ((ActionOutcome) -> ())? = nil) {
-        ActionSession.main.perform(self, using: NoPresenter(), with: NoInput.none, userInitiated: userInitiated, source: source, completion: completion)
+        ActionSession.main.perform(self, input: .none, presenter: NoPresenter(), userInitiated: userInitiated, source: source, completion: completion)
     }
 }

--- a/FlintCore/Core/ActionDispatcher.swift
+++ b/FlintCore/Core/ActionDispatcher.swift
@@ -83,8 +83,9 @@ public class DefaultActionDispatcher: ActionDispatcher {
         let action = request.actionBinding.action
         let smartQueue = SmartDispatchQueue(queue: action.queue, owner: self)
         smartQueue.sync {
-            action.perform(with: request.context,
-                           using: request.presenter, completion: { outcome in
+            action.perform(context: request.context,
+                           presenter: request.presenter,
+                           completion: { outcome in
                 self.complete(request: request, outcome: outcome)
                 callerQueue.sync {
                     completion?(outcome)

--- a/FlintCore/Core/ActionSession.swift
+++ b/FlintCore/Core/ActionSession.swift
@@ -99,10 +99,10 @@ public class ActionSession: CustomDebugStringConvertible {
     /// - param input: The value to pass as the input of the action
     /// - param completion: The completion handler to call.
     public func perform<FeatureType, ActionType>(_ conditionalRequest: ConditionalActionRequest<FeatureType, ActionType>,
-                                                 using presenter: ActionType.PresenterType,
-                                                 with input: ActionType.InputType,
+                                                 input: ActionType.InputType,
+                                                 presenter: ActionType.PresenterType,
                                                  completion: ((ActionOutcome) -> ())? = nil) {
-        perform(conditionalRequest, using: presenter, with: input, userInitiated: userInitiatedActions, source: .application, completion: completion)
+        perform(conditionalRequest, input: input, presenter: presenter, userInitiated: userInitiatedActions, source: .application, completion: completion)
     }
     
     /// Perform the action associated with a conditional request obtained from `ConditionalFeature.request`.
@@ -111,14 +111,13 @@ public class ActionSession: CustomDebugStringConvertible {
     ///
     /// The completion handler is called on `callerQueue` of this `ActionSession`
     ///
-    /// - param presenter: The object presenting the outcome of the action
     /// - param input: The value to pass as the input of the action
     /// - param completion: The completion handler to call.
     public func perform<FeatureType, ActionType>(_ conditionalRequest: ConditionalActionRequest<FeatureType, ActionType>,
-                                                 with input: ActionType.InputType,
+                                                 input: ActionType.InputType,
                                                  completion: ((ActionOutcome) -> ())? = nil)
                                                  where ActionType.PresenterType == NoPresenter {
-        perform(conditionalRequest, using: NoPresenter(), with: input, userInitiated: userInitiatedActions, source: .application, completion: completion)
+        perform(conditionalRequest, input: input, presenter: NoPresenter(), userInitiated: userInitiatedActions, source: .application, completion: completion)
     }
 
     /// Perform the action associated with a conditional request obtained from `ConditionalFeature.request`.
@@ -128,13 +127,12 @@ public class ActionSession: CustomDebugStringConvertible {
     /// The completion handler is called on `callerQueue` of this `ActionSession`
     ///
     /// - param presenter: The object presenting the outcome of the action
-    /// - param input: The value to pass as the input of the action
     /// - param completion: The completion handler to call.
     public func perform<FeatureType, ActionType>(_ conditionalRequest: ConditionalActionRequest<FeatureType, ActionType>,
-                                                 using presenter: ActionType.PresenterType,
+                                                 presenter: ActionType.PresenterType,
                                                  completion: ((ActionOutcome) -> ())? = nil)
                                                  where ActionType.InputType == NoInput {
-        perform(conditionalRequest, using: presenter, with: .none, userInitiated: userInitiatedActions, source: .application, completion: completion)
+        perform(conditionalRequest, input: .none, presenter: presenter, userInitiated: userInitiatedActions, source: .application, completion: completion)
     }
 
     /// Perform the action associated with a conditional request obtained from `ConditionalFeature.request`.
@@ -143,13 +141,11 @@ public class ActionSession: CustomDebugStringConvertible {
     ///
     /// The completion handler is called on `callerQueue` of this `ActionSession`
     ///
-    /// - param presenter: The object presenting the outcome of the action
-    /// - param input: The value to pass as the input of the action
     /// - param completion: The completion handler to call.
     public func perform<FeatureType, ActionType>(_ conditionalRequest: ConditionalActionRequest<FeatureType, ActionType>,
                                                  completion: ((ActionOutcome) -> ())? = nil)
                                                  where ActionType.InputType == NoInput, ActionType.PresenterType == NoPresenter {
-        perform(conditionalRequest, using: NoPresenter(), with: .none, userInitiated: userInitiatedActions, source: .application, completion: completion)
+        perform(conditionalRequest, input: .none, presenter: NoPresenter(), userInitiated: userInitiatedActions, source: .application, completion: completion)
     }
 
     /// Perform the action associated with a conditional request obtained from `ConditionalFeature.request`.
@@ -164,11 +160,11 @@ public class ActionSession: CustomDebugStringConvertible {
     /// - param source: Indicates where the request came from
     /// - param completion: The completion handler to call.
     public func perform<FeatureType, ActionType>(_ conditionalRequest: ConditionalActionRequest<FeatureType, ActionType>,
-                       using presenter: ActionType.PresenterType,
-                       with input: ActionType.InputType,
-                       userInitiated: Bool,
-                       source: ActionSource,
-                       completion: ((ActionOutcome) -> ())? = nil) {
+                                                 input: ActionType.InputType,
+                                                 presenter: ActionType.PresenterType,
+                                                 userInitiated: Bool,
+                                                 source: ActionSource,
+                                                 completion: ((ActionOutcome) -> ())? = nil) {
         let staticBinding = StaticActionBinding(feature: conditionalRequest.actionBinding.feature, action: conditionalRequest.actionBinding.action)
         let logContextCreator = { (sessionID, activitySequenceID) in
             return LogEventContext(session: sessionID,
@@ -199,10 +195,10 @@ public class ActionSession: CustomDebugStringConvertible {
     /// - param input: The value to pass as the input of the action
     /// - param completion: The completion handler to call.
     public func perform<FeatureType, ActionType>(_ actionBinding: StaticActionBinding<FeatureType, ActionType>,
-                                                 using presenter: ActionType.PresenterType,
-                                                 with input: ActionType.InputType,
+                                                 input: ActionType.InputType,
+                                                 presenter: ActionType.PresenterType,
                                                  completion: ((ActionOutcome) -> ())? = nil) {
-        perform(actionBinding, using: presenter, with: input, userInitiated: userInitiatedActions,
+        perform(actionBinding, input: input, presenter: presenter, userInitiated: userInitiatedActions,
                 source: .application, completion: completion)
     }
     
@@ -215,10 +211,10 @@ public class ActionSession: CustomDebugStringConvertible {
     /// - param input: The value to pass as the input of the action
     /// - param completion: The completion handler to call.
     public func perform<FeatureType, ActionType>(_ actionBinding: StaticActionBinding<FeatureType, ActionType>,
-                                                 with input: ActionType.InputType,
+                                                 input: ActionType.InputType,
                                                  completion: ((ActionOutcome) -> ())? = nil)
                                                  where ActionType.PresenterType == NoPresenter {
-        perform(actionBinding, using: NoPresenter(), with: input, userInitiated: userInitiatedActions,
+        perform(actionBinding, input: input, presenter: NoPresenter(), userInitiated: userInitiatedActions,
                 source: .application, completion: completion)
     }
 
@@ -228,13 +224,13 @@ public class ActionSession: CustomDebugStringConvertible {
     ///
     /// The completion handler is called on `callerQueue` of this `ActionSession`
     ///
-    /// - param input: The value to pass as the input of the action
+    /// - param presenter: The presenter to pass to the action
     /// - param completion: The completion handler to call.
     public func perform<FeatureType, ActionType>(_ actionBinding: StaticActionBinding<FeatureType, ActionType>,
-                                                 using presenter: ActionType.PresenterType,
+                                                 presenter: ActionType.PresenterType,
                                                  completion: ((ActionOutcome) -> ())? = nil)
                                                  where ActionType.InputType == NoInput {
-        perform(actionBinding, using: presenter, with: .none, userInitiated: userInitiatedActions,
+        perform(actionBinding, input: .none, presenter: presenter, userInitiated: userInitiatedActions,
                 source: .application, completion: completion)
     }
 
@@ -245,12 +241,11 @@ public class ActionSession: CustomDebugStringConvertible {
     ///
     /// The completion handler is called on `callerQueue` of this `ActionSession`
     ///
-    /// - param input: The value to pass as the input of the action
     /// - param completion: The completion handler to call.
     public func perform<FeatureType, ActionType>(_ actionBinding: StaticActionBinding<FeatureType, ActionType>,
                                                  completion: ((ActionOutcome) -> ())? = nil)
                                                  where ActionType.InputType == NoInput, ActionType.PresenterType == NoPresenter {
-        perform(actionBinding, using: NoPresenter(), with: .none, userInitiated: userInitiatedActions,
+        perform(actionBinding, input: .none, presenter: NoPresenter(), userInitiated: userInitiatedActions,
                 source: .application, completion: completion)
     }
 
@@ -266,11 +261,11 @@ public class ActionSession: CustomDebugStringConvertible {
     /// - param source: Indicates where the request came from
     /// - param completion: The completion handler to call.
     public func perform<FeatureType, ActionType>(_ actionBinding: StaticActionBinding<FeatureType, ActionType>,
-                       using presenter: ActionType.PresenterType,
-                       with input: ActionType.InputType,
-                       userInitiated: Bool,
-                       source: ActionSource,
-                       completion: ((ActionOutcome) -> ())? = nil) {
+                                                 input: ActionType.InputType,
+                                                 presenter: ActionType.PresenterType,
+                                                 userInitiated: Bool,
+                                                 source: ActionSource,
+                                                 completion: ((ActionOutcome) -> ())? = nil) {
         let logContextCreator = { (sessionID, activitySequenceID) in
             return LogEventContext(session: sessionID,
                                    activity: activitySequenceID,

--- a/FlintCore/Core/Flint.swift
+++ b/FlintCore/Core/Flint.swift
@@ -255,7 +255,7 @@ final public class Flint {
         requiresSetup()
         if let request = RoutesFeature.performIncomingURL.request() {
             var performOutcome: ActionOutcome?
-            ActionSession.main.perform(request, using: presentationRouter, with: url, userInitiated: true, source: .openURL) { outcome in
+            ActionSession.main.perform(request, input: url, presenter: presentationRouter, userInitiated: true, source: .openURL) { outcome in
                 FlintInternal.logger?.debug("Activity auto URL result: \(outcome)")
                 performOutcome = outcome
             }
@@ -326,7 +326,7 @@ final public class Flint {
 #endif
             }
             
-            ActionSession.main.perform(request, using: presentationRouter, with: activity, userInitiated: true, source: source) { outcome in
+            ActionSession.main.perform(request, input: activity, presenter: presentationRouter, userInitiated: true, source: source) { outcome in
                 FlintInternal.logger?.debug("Activity auto continue result: \(outcome)")
                 performOutcome = outcome
             }

--- a/FlintCore/Focus/FocusFeature.swift
+++ b/FlintCore/Focus/FocusFeature.swift
@@ -84,7 +84,7 @@ final public class FocusAction: Action {
     public typealias InputType = FocusArea
     public typealias PresenterType = NoPresenter
 
-    public static func perform(with context: ActionContext<InputType>, using presenter: PresenterType, completion: @escaping (ActionPerformOutcome) -> Void) {
+    public static func perform(context: ActionContext<InputType>, presenter: PresenterType, completion: @escaping (ActionPerformOutcome) -> Void) {
         FocusFeature.dependencies.focusSelection?.focus(context.input.topicPath)
         
         completion(.success(closeActionStack: true))
@@ -95,7 +95,7 @@ final public class DefocusAction: Action {
     public typealias InputType = FocusArea
     public typealias PresenterType = NoPresenter
 
-    public static func perform(with context: ActionContext<InputType>, using presenter: PresenterType, completion: @escaping (ActionPerformOutcome) -> Void) {
+    public static func perform(context: ActionContext<InputType>, presenter: PresenterType, completion: @escaping (ActionPerformOutcome) -> Void) {
         FocusFeature.dependencies.focusSelection?.defocus(context.input.topicPath)
 
         completion(.success(closeActionStack: true))
@@ -106,7 +106,7 @@ final public class ResetFocusAction: Action {
     public typealias InputType = NoInput
     public typealias PresenterType = NoPresenter
 
-    public static func perform(with context: ActionContext<InputType>, using presenter: PresenterType, completion: @escaping (ActionPerformOutcome) -> Void) {
+    public static func perform(context: ActionContext<InputType>, presenter: PresenterType, completion: @escaping (ActionPerformOutcome) -> Void) {
         FocusFeature.dependencies.focusSelection?.reset()
 
         completion(.success(closeActionStack: true))

--- a/FlintCore/Routes/PerformIncomingURLAction.swift
+++ b/FlintCore/Routes/PerformIncomingURLAction.swift
@@ -36,7 +36,7 @@ final public class PerformIncomingURLAction: Action {
     ///
     /// The completion outcome will fail with error `noURLMappingFound` if the URL does not map to anything
     /// that Flint knows about.
-    public static func perform(with context: ActionContext<URL>, using presenter: PresentationRouter, completion: @escaping (ActionPerformOutcome) -> Void) {
+    public static func perform(context: ActionContext<URL>, presenter: PresentationRouter, completion: @escaping (ActionPerformOutcome) -> Void) {
         guard let urlComponents = URLComponents(url: context.input, resolvingAgainstBaseURL: false) else {
             context.logs.development?.error("Invalid URL supplied")
             return completion(.failure(error: nil, closeActionStack: false))

--- a/FlintCore/Routes/PresentationRouter.swift
+++ b/FlintCore/Routes/PresentationRouter.swift
@@ -44,10 +44,10 @@ public protocol PresentationRouter {
     /// Called to obtain the presenter, if possible, for the static action binding provided.
     /// - return: The outcome of the presentation routing.
     /// - see: `PresentationResult<PresenterType>`
-    func presentation<FeatureType, ActionType>(for actionBinding: StaticActionBinding<FeatureType, ActionType>, with state: ActionType.InputType) -> PresentationResult<ActionType.PresenterType>
+    func presentation<FeatureType, ActionType>(for actionBinding: StaticActionBinding<FeatureType, ActionType>, input: ActionType.InputType) -> PresentationResult<ActionType.PresenterType>
     
     /// Called to obtain the presenter, if possible, for the conditional action binding provided.
     /// - return: The outcome of the presentation routing.
     /// - see: `PresentationResult<PresenterType>`
-    func presentation<FeatureType, ActionType>(for conditionalActionBinding: ConditionalActionBinding<FeatureType, ActionType>, with state: ActionType.InputType) -> PresentationResult<ActionType.PresenterType>
+    func presentation<FeatureType, ActionType>(for conditionalActionBinding: ConditionalActionBinding<FeatureType, ActionType>, input: ActionType.InputType) -> PresentationResult<ActionType.PresenterType>
 }

--- a/FlintCore/Routes/URLMappingsBuilder.swift
+++ b/FlintCore/Routes/URLMappingsBuilder.swift
@@ -24,14 +24,14 @@ public class URLMappingsBuilder {
         let executor: URLExecutor = { (queryParams: RouteParameters?, presentationRouter: PresentationRouter, source: ActionSource, completion: (ActionPerformOutcome) -> Void) in
             FlintInternal.urlMappingLogger?.debug("In URL executor for mapping \(mapping) to \(actionBinding)")
       
-            if let state = ActionType.InputType.init(from: queryParams, mapping: mapping) {
+            if let input = ActionType.InputType.init(from: queryParams, mapping: mapping) {
 
-                let presentationRouterResult = presentationRouter.presentation(for: actionBinding, with: state)
+                let presentationRouterResult = presentationRouter.presentation(for: actionBinding, with: input)
 
-                FlintInternal.urlMappingLogger?.debug("URL executor presentation \(presentationRouterResult) received for \(actionBinding) with state \(state)")
+                FlintInternal.urlMappingLogger?.debug("URL executor presentation \(presentationRouterResult) received for \(actionBinding) with input \(input)")
                 switch presentationRouterResult {
                     case .appReady(let presenter):
-                        actionBinding.perform(using: presenter, with: state, userInitiated: true, source: source)
+                        actionBinding.perform(input: input, presenter: presenter, userInitiated: true, source: source)
                     case .unsupported:
                         FlintInternal.urlMappingLogger?.error("No presentation for mapping \(mapping) for \(actionBinding) - received .unsupported")
                     case .appCancelled, .userCancelled, .appPerformed:
@@ -61,13 +61,13 @@ public class URLMappingsBuilder {
 
         let executor: URLExecutor = { (queryParams: RouteParameters?, presentationRouter: PresentationRouter, source: ActionSource, completion: (ActionPerformOutcome) -> Void) in
             FlintInternal.urlMappingLogger?.debug("In URL executor for mapping \(mapping) to \(actionBinding)")
-            if let state = ActionType.InputType.init(from: queryParams, mapping: mapping) {
-                let result = presentationRouter.presentation(for: actionBinding, with: state)
-                FlintInternal.urlMappingLogger?.debug("URL executor presentation \(result) received for \(actionBinding) with state \(state)")
+            if let input = ActionType.InputType.init(from: queryParams, mapping: mapping) {
+                let result = presentationRouter.presentation(for: actionBinding, with: input)
+                FlintInternal.urlMappingLogger?.debug("URL executor presentation \(result) received for \(actionBinding) with input \(input)")
                 switch result {
                     case .appReady(let presenter):
                         if let request = actionBinding.request() {
-                            request.perform(using: presenter, with: state, userInitiated: true, source: source)
+                            request.perform(input: input, presenter: presenter, userInitiated: true, source: source)
                         }
                     case .unsupported:
                         FlintInternal.urlMappingLogger?.error("No presentation for mapping \(mapping) for \(actionBinding) - received .unsupported")

--- a/FlintCore/Routes/URLMappingsBuilder.swift
+++ b/FlintCore/Routes/URLMappingsBuilder.swift
@@ -26,7 +26,7 @@ public class URLMappingsBuilder {
       
             if let input = ActionType.InputType.init(from: queryParams, mapping: mapping) {
 
-                let presentationRouterResult = presentationRouter.presentation(for: actionBinding, with: input)
+                let presentationRouterResult = presentationRouter.presentation(for: actionBinding, input: input)
 
                 FlintInternal.urlMappingLogger?.debug("URL executor presentation \(presentationRouterResult) received for \(actionBinding) with input \(input)")
                 switch presentationRouterResult {
@@ -62,7 +62,7 @@ public class URLMappingsBuilder {
         let executor: URLExecutor = { (queryParams: RouteParameters?, presentationRouter: PresentationRouter, source: ActionSource, completion: (ActionPerformOutcome) -> Void) in
             FlintInternal.urlMappingLogger?.debug("In URL executor for mapping \(mapping) to \(actionBinding)")
             if let input = ActionType.InputType.init(from: queryParams, mapping: mapping) {
-                let result = presentationRouter.presentation(for: actionBinding, with: input)
+                let result = presentationRouter.presentation(for: actionBinding, input: input)
                 FlintInternal.urlMappingLogger?.debug("URL executor presentation \(result) received for \(actionBinding) with input \(input)")
                 switch result {
                     case .appReady(let presenter):

--- a/FlintCoreTests/Test Features/DummyFeature.swift
+++ b/FlintCoreTests/Test Features/DummyFeature.swift
@@ -26,7 +26,7 @@ final class DummyAction: Action {
     typealias InputType = NoInput
     typealias PresenterType = NoPresenter
     
-    static func perform(with context: ActionContext<DummyAction.InputType>, using presenter: DummyAction.PresenterType, completion: @escaping (ActionPerformOutcome) -> Void) {
+    static func perform(context: ActionContext<DummyAction.InputType>, presenter: DummyAction.PresenterType, completion: @escaping (ActionPerformOutcome) -> Void) {
         completion(.success(closeActionStack: true))
     }
 }

--- a/FlintUI/Features/ActionStackBrowserFeature.swift
+++ b/FlintUI/Features/ActionStackBrowserFeature.swift
@@ -33,7 +33,7 @@ final public class ShowActionStackBrowserAction: Action {
 
     public static var hideFromTimeline: Bool = true
 
-    public static func perform(with context: ActionContext<InputType>, using presenter: PresenterType, completion: @escaping (ActionPerformOutcome) -> Void) {
+    public static func perform(context: ActionContext<InputType>, presenter: PresenterType, completion: @escaping (ActionPerformOutcome) -> Void) {
         let actionStacksViewController = ActionStackListViewController.instantiate()
         if let navigationController = presenter as? UINavigationController {
             navigationController.pushViewController(actionStacksViewController, animated: true)

--- a/FlintUI/Features/FeatureBrowserFeature.swift
+++ b/FlintUI/Features/FeatureBrowserFeature.swift
@@ -34,7 +34,7 @@ final public class ShowFeatureBrowserAction: Action {
 
     public static var hideFromTimeline: Bool = true
 
-    public static func perform(with context: ActionContext<InputType>, using presenter: PresenterType, completion: @escaping (ActionPerformOutcome) -> Void) {
+    public static func perform(context: ActionContext<InputType>, presenter: PresenterType, completion: @escaping (ActionPerformOutcome) -> Void) {
         let featuresViewController = FeatureBrowserViewController.instantiate()
         if let navigationController = presenter as? UINavigationController {
             navigationController.pushViewController(featuresViewController, animated: true)

--- a/FlintUI/Features/FocusLogDataAccessFeature.swift
+++ b/FlintUI/Features/FocusLogDataAccessFeature.swift
@@ -39,7 +39,7 @@ final public class FocusLogDataAccessFeature: ConditionalFeature {
 
         public static var hideFromTimeline: Bool = true
         
-        public static func perform(with context: ActionContext<InputType>, using presenter: PresenterType, completion: @escaping (ActionPerformOutcome) -> Void) {
+        public static func perform(context: ActionContext<InputType>, presenter: PresenterType, completion: @escaping (ActionPerformOutcome) -> Void) {
             guard let logs = FocusFeature.dependencies.developmentFocusLogging else {
                 completion(.success(closeActionStack: true))
                 return
@@ -63,7 +63,7 @@ final public class FocusLogDataAccessFeature: ConditionalFeature {
 
         public static let defaultExtraPageCount = 10
         
-        public static func perform(with context: ActionContext<InputType>, using presenter: PresenterType, completion: @escaping (ActionPerformOutcome) -> Void) {
+        public static func perform(context: ActionContext<InputType>, presenter: PresenterType, completion: @escaping (ActionPerformOutcome) -> Void) {
             guard let focusLogController = presenter.focusLogController else {
                 flintBug("Initial results have not been loaded")
             }

--- a/FlintUI/Features/LogBrowserFeature.swift
+++ b/FlintUI/Features/LogBrowserFeature.swift
@@ -38,7 +38,7 @@ final public class ShowLogBrowserAction: Action {
 
     public static var hideFromTimeline: Bool = true
 
-    public static func perform(with context: ActionContext<InputType>, using presenter: PresenterType, completion: @escaping (ActionPerformOutcome) -> Void) {
+    public static func perform(context: ActionContext<InputType>, presenter: PresenterType, completion: @escaping (ActionPerformOutcome) -> Void) {
         let focusLogViewController = FocusLogViewController.instantiate()
         if let navigationController = presenter as? UINavigationController {
             context.logs.development?.debug("Presenting Focus Log VC on navigation controller")

--- a/FlintUI/Features/TimelineBrowserFeature.swift
+++ b/FlintUI/Features/TimelineBrowserFeature.swift
@@ -40,7 +40,7 @@ final public class ShowTimelineBrowserAction: Action {
 
     public static var hideFromTimeline: Bool = true
 
-    public static func perform(with context: ActionContext<InputType>, using presenter: PresenterType, completion: @escaping (ActionPerformOutcome) -> Void) {
+    public static func perform(context: ActionContext<InputType>, presenter: PresenterType, completion: @escaping (ActionPerformOutcome) -> Void) {
         let timelineViewController = TimelineViewController.instantiate()
         if let navigationController = presenter as? UINavigationController {
             context.logs.development?.debug("Presenting timeline VC on navigation controller")
@@ -57,7 +57,7 @@ public protocol TerminatingAction: Action {
 }
 
 extension TerminatingAction {
-    public static func perform(with context: ActionContext<InputType>, using presenter: PresenterType, completion: @escaping (ActionPerformOutcome) -> Void) {
+    public static func perform(context: ActionContext<InputType>, presenter: PresenterType, completion: @escaping (ActionPerformOutcome) -> Void) {
         completion(.success(closeActionStack: true))
     }
 }

--- a/FlintUI/Features/TimelineDataAccessFeature.swift
+++ b/FlintUI/Features/TimelineDataAccessFeature.swift
@@ -39,7 +39,7 @@ final public class TimelineDataAccessFeature: ConditionalFeature {
 
         public static var hideFromTimeline: Bool = true
 
-        public static func perform(with context: ActionContext<InputType>, using presenter: PresenterType, completion: @escaping (ActionPerformOutcome) -> Void) {
+        public static func perform(context: ActionContext<InputType>, presenter: PresenterType, completion: @escaping (ActionPerformOutcome) -> Void) {
             let timeline = Timeline.instance
             let timelineController = TimeOrderedResultsController(dataSource: timeline.entries, delegate: presenter, delegateQueue: .main)
             presenter.timelineController = timelineController
@@ -58,7 +58,7 @@ final public class TimelineDataAccessFeature: ConditionalFeature {
 
         public static let defaultExtraPageCount = 10
         
-        public static func perform(with context: ActionContext<InputType>, using presenter: PresenterType, completion: @escaping (ActionPerformOutcome) -> Void) {
+        public static func perform(context: ActionContext<InputType>, presenter: PresenterType, completion: @escaping (ActionPerformOutcome) -> Void) {
             guard let timelineController = presenter.timelineController else {
                 flintBug("Initial results have not been loaded")
             }

--- a/FlintUI/iOS/View Controllers/FocusLogViewController.swift
+++ b/FlintUI/iOS/View Controllers/FocusLogViewController.swift
@@ -42,7 +42,7 @@ public class FocusLogViewController: UITableViewController, FocusLogPresenter {
             present(alertController, animated: true)
             return
         }
-        request.perform(using: self, with: 20)
+        request.perform(input: 20, presenter: self)
     }
     
     // MARK: Table View
@@ -79,7 +79,7 @@ public class FocusLogViewController: UITableViewController, FocusLogPresenter {
             guard let request = FocusLogDataAccessFeature.request(FocusLogDataAccessFeature.loadMoreResults) else {
                 flintUsageError("This UI requires that FocusLogFeature is enabled. Set FocusLogFeature.isAvailable = true at startup.")
             }
-            request.perform(using: self, with: 20)
+            request.perform(input: 20, presenter: self)
             return nil
         }
         let entry = items[indexPath.item]

--- a/FlintUI/iOS/View Controllers/TimelineViewController.swift
+++ b/FlintUI/iOS/View Controllers/TimelineViewController.swift
@@ -40,7 +40,7 @@ public class TimelineViewController: UITableViewController, TimelinePresenter {
             present(alertController, animated: true)
             return
         }
-        request.perform(using: self, with: 20)
+        request.perform(input: 20, presenter: self)
     }
 
     override public func didReceiveMemoryWarning() {
@@ -106,7 +106,7 @@ public class TimelineViewController: UITableViewController, TimelinePresenter {
             guard let request = TimelineDataAccessFeature.request(TimelineDataAccessFeature.loadMoreResults) else {
                 flintUsageError("This UI requires that TimelineFeature is enabled. Set TimelineFeature.isAvailable = true at startup.")
             }
-            request.perform(using: self, with: 20)
+            request.perform(input: 20, presenter: self)
             return nil
         }
         let entry = items[indexPath.item]

--- a/FlintUISandbox/AppDelegate.swift
+++ b/FlintUISandbox/AppDelegate.swift
@@ -42,7 +42,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         testTimer?.setEventHandler(handler: {
             print("Performing a fake action, this will show even if not in Focus")
             if let request = FakeFeature.action1.request() {
-                request.perform(with: nil)
+                request.perform(input: nil)
             } else {
                 print("NOT Performing the fake action, permissions were not available")
             }

--- a/FlintUISandbox/AppDelegate.swift
+++ b/FlintUISandbox/AppDelegate.swift
@@ -12,12 +12,12 @@ import FlintUI
 
 class FakePresentationRouter: PresentationRouter {
     func presentation<FeatureType, ActionType>(for actionBinding: StaticActionBinding<FeatureType, ActionType>,
-                                               with state: ActionType.InputType) -> PresentationResult<ActionType.PresenterType> {
+                                               input: ActionType.InputType) -> PresentationResult<ActionType.PresenterType> {
         return .appPerformed
     }
     
     func presentation<FeatureType, ActionType>(for conditionalActionBinding: ConditionalActionBinding<FeatureType, ActionType>,
-                                               with state: ActionType.InputType) -> PresentationResult<ActionType.PresenterType> {
+                                               input: ActionType.InputType) -> PresentationResult<ActionType.PresenterType> {
         return .appPerformed
     }
 } 

--- a/FlintUISandbox/FakeFeatures.swift
+++ b/FlintUISandbox/FakeFeatures.swift
@@ -33,7 +33,7 @@ final class FakeFeature: ConditionalFeature, URLMapped {
     }
     
     static func urlMappings(routes: URLMappingsBuilder) {
-        routes.send("/*", to: action1)
+        routes.send("/test", to: action1)
     }
 }
 

--- a/FlintUISandbox/FakeFeatures.swift
+++ b/FlintUISandbox/FakeFeatures.swift
@@ -64,7 +64,7 @@ final class DoSomethingFakeAction: Action {
         activity.userInfo["fake"] = true
     }
 
-    static func perform(with context: ActionContext<InputType>, using presenter: PresenterType, completion: @escaping (ActionPerformOutcome) -> Void) {
+    static func perform(context: ActionContext<InputType>, presenter: PresenterType, completion: @escaping (ActionPerformOutcome) -> Void) {
         context.logs.development?.info("Testing logs from fake feature")
         completion(.success(closeActionStack: true))
     }

--- a/FlintUISandbox/ViewController.swift
+++ b/FlintUISandbox/ViewController.swift
@@ -17,7 +17,7 @@ class ViewController: UITableViewController {
 
         // Trigger some fake data
         if let request = FakeFeature.action1.request() {
-            request.perform(with: .none, completion: { (outcome: ActionOutcome) in
+            request.perform(input: .none, completion: { (outcome: ActionOutcome) in
                 switch outcome {
                     case .success:
                        assert(true)
@@ -25,7 +25,7 @@ class ViewController: UITableViewController {
                        assert(false)
                 }
             })
-            request.perform(with: .none, userInitiated: false, source: .application, completion: { (outcome: ActionOutcome) in
+            request.perform(input: .none, userInitiated: false, source: .application, completion: { (outcome: ActionOutcome) in
                 switch outcome {
                     case .success:
                        assert(true)
@@ -50,22 +50,22 @@ class ViewController: UITableViewController {
                 guard let request = FeatureBrowserFeature.request(FeatureBrowserFeature.show) else {
                     preconditionFailure("Feature browser is not enabled")
                 }
-                request.perform(using: navigationController)
+                request.perform(presenter: navigationController)
             case 1:
                 guard let request = TimelineBrowserFeature.request(TimelineBrowserFeature.show) else {
                     preconditionFailure("Timeline is not enabled")
                 }
-                request.perform(using: navigationController)
+                request.perform(presenter: navigationController)
             case 2:
                 guard let request = ActionStackBrowserFeature.request(ActionStackBrowserFeature.show) else {
                     preconditionFailure("Action Stack is not enabled")
                 }
-                request.perform(using: navigationController)
+                request.perform(presenter: navigationController)
             case 3:
                 guard let request = LogBrowserFeature.request(LogBrowserFeature.show) else {
                     preconditionFailure("Log Browser is not enabled")
                 }
-                request.perform(using: navigationController)
+                request.perform(presenter: navigationController)
             default: preconditionFailure()
         }
         

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ When you need to perform an action from a conditional feature, you are forced to
 
 ```swift
 if let request = DocumentSharingFeature.share.request() {
-    request.perform(input: document, presenter: presenter, with: document)
+    request.perform(input: document, presenter: presenter)
 } else {
     showPremiumUpgradeOrPermissionAuthorisations()
 }

--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ When you need to perform an action from a conditional feature, you are forced to
 
 ```swift
 if let request = DocumentSharingFeature.share.request() {
-    request.perform(using: presenter, with: document)
+    request.perform(input: document, presenter: presenter, with: document)
 } else {
     showPremiumUpgradeOrPermissionAuthorisations()
 }
@@ -136,7 +136,7 @@ The action type `ConfirmAccountAction` is not shown here, for brevity. See the [
 Of course you can easily perform this same action from code in your app if required:
 
 ```swift
-UserAccountManagementFeature.confirmAccount.perform(using: presenter, with: confirmationToken)
+UserAccountManagementFeature.confirmAccount.perform(input: confirmationToken, presenter: presenter)
 ```
 
 If you need to, you can create URLs that link to these mapped actions using [`Flint.linkCreator`](https://github.com/MontanaFlossCo/Flint/blob/master/FlintCore/Core/Flint.swift). 

--- a/README.md
+++ b/README.md
@@ -49,8 +49,8 @@ final class DocumentOpenAction: Action {
 
     static var description = "Open a document"
     
-    static func perform(with context: ActionContext<DocumentRef>,
-                        using presenter: DocumentPresenter,
+    static func perform(context: ActionContext<DocumentRef>,
+                        presenter: DocumentPresenter,
                         completion: @escaping ((ActionPerformOutcome) -> ())) {
         presenter.openDocument(context.input)
         completion(.success(closeActionStack: false))
@@ -159,7 +159,7 @@ final class DocumentOpenAction: Action {
     // 💥 Just tell Flint what activity types to use
     static var activityTypes: Set<ActivityEligibility> = [.perform, .handoff]
     
-    static func perform(with context: ActionContext<DocumentRef>, using presenter: DocumentPresenter, completion: ((ActionPerformOutcome) -> ())) {
+    static func perform(context: ActionContext<DocumentRef>, presenter: DocumentPresenter, completion: ((ActionPerformOutcome) -> ())) {
         // … do the work
     }
 }
@@ -187,7 +187,7 @@ final class DocumentOpenAction: Action {
     // 💥 Enable analytics with just one property.
     static var analyticsID = "user-open-document"
     
-    static func perform(with context: ActionContext<DocumentRef>, using presenter: DocumentPresenter, completion: ((ActionPerformOutcome) -> ())) {
+    static func perform(context: ActionContext<DocumentRef>, presenter: DocumentPresenter, completion: ((ActionPerformOutcome) -> ())) {
         // … do the work
     }
 }


### PR DESCRIPTION
See #143 which states the problem that "with" and "using" do not make it clear which is input and which is presenter. Natural language forms like this appear to work best when there is only one "subject" which naturally disambiguates it.

I renamed related public functions that take input/presenters too, on:

* ActionSession
* StaticActionBinding & ConditionalActionBinding (the primary API touch points)
* PresentationRouter
* Action

The rest is all fix up for internals and FlintUISandbox so they compile and run as before.