### PR TITLE
Allow easy creation of feature-specific loggers for use outside of actions

### DIFF
--- a/FlintCore/Conditional Features/ConditionalFeature.swift
+++ b/FlintCore/Conditional Features/ConditionalFeature.swift
@@ -66,6 +66,31 @@ public extension ConditionalFeature {
         return ConditionalActionRequest(actionBinding: actionBinding)
     }
 
+
+    /// Create a new context-specific logger with this feature as the context (topic path).
+    /// - param activity: A string that identifies the kind of activity that will be generating log entries, e.g. "bg upload"
+    /// - return: A logger if running in a development build, else nil. You must store the result of this call to avoid
+    /// re-creating the loggers every time this function is called.
+    public static func developmentLogger(for activity: String) -> ContextSpecificLogger? {
+        if let factory = Logging.development {
+            return factory.contextualLogger(with: activity, topicPath: self.identifier)
+        } else {
+            return nil
+        }
+    }
+
+    /// Create a new context-specific logger with this feature as the context (topic path).
+    /// - param activity: A string that identifies the kind of activity that will be generating log entries, e.g. "bg upload"
+    /// - return: A logger if running in a production build, else nil. You must store the result of this call to avoid
+    /// re-creating the loggers every time this function is called.
+    public static func productionLogger(for activity: String) -> ContextSpecificLogger? {
+        if let factory = Logging.production {
+            return factory.contextualLogger(with: activity, topicPath: self.identifier)
+        } else {
+            return nil
+        }
+    }
+    
     /// Access information about the permissions required by this feature
     public static var permissions: FeaturePermissionRequirements {
         let constraints = Flint.constraintsEvaluator.evaluate(for: self)

--- a/FlintCore/Features/Feature.swift
+++ b/FlintCore/Features/Feature.swift
@@ -56,4 +56,27 @@ public extension Feature {
         return StaticActionBinding(feature: self, action: action)
     }
 
+    /// Create a new context-specific logger with this feature as the context (topic path).
+    /// - param activity: A string that identifies the kind of activity that will be generating log entries, e.g. "bg upload"
+    /// - return: A logger if running in a development build, else nil. You must store the result of this call to avoid
+    /// re-creating the loggers every time this function is called.
+    public static func developmentLogger(for activity: String) -> ContextSpecificLogger? {
+        if let factory = Logging.development {
+            return factory.contextualLogger(with: activity, topicPath: self.identifier)
+        } else {
+            return nil
+        }
+    }
+
+    /// Create a new context-specific logger with this feature as the context (topic path).
+    /// - param activity: A string that identifies the kind of activity that will be generating log entries, e.g. "bg upload"
+    /// - return: A logger if running in a production build, else nil. You must store the result of this call to avoid
+    /// re-creating the loggers every time this function is called.
+    public static func productionLogger(for activity: String) -> ContextSpecificLogger? {
+        if let factory = Logging.production {
+            return factory.contextualLogger(with: activity, topicPath: self.identifier)
+        } else {
+            return nil
+        }
+    }
 }

--- a/FlintUISandbox/AppDelegate.swift
+++ b/FlintUISandbox/AppDelegate.swift
@@ -35,18 +35,18 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         
         // Spit out a fake action every few seconds
         
-        let logger = Logging.development?.contextualLogger(with: "Testing", topicPath: TopicPath(feature: FakeFeatures.self))
+        let bgLogger = FakeFeature.developmentLogger(for: "BG Timer")
 
         testTimer = DispatchSource.makeTimerSource(flags: [], queue: .main)
         testTimer?.schedule(deadline: DispatchTime.now(), repeating: 10.0)
         testTimer?.setEventHandler(handler: {
-            print("Performing a fake action, this will show even if not in Focus")
+            bgLogger?.debug("Performing a fake action, this will show even if not in Focus")
             if let request = FakeFeature.action1.request() {
                 request.perform(input: nil)
             } else {
                 print("NOT Performing the fake action, permissions were not available")
             }
-            logger?.debug("Test output from logger")
+            bgLogger?.debug("Test output from logger")
         })
         testTimer?.resume()
         


### PR DESCRIPTION
This adds two new static functions to all feature types:

* `developmentLogger(for:)`
* `productionLogger(for:)`

You pass an activity string used in the log entries, e.g. "bg processing" to identify "what caused these events", and these events will be logged under the feature's topic path.