### PR TITLE
Remove external ZIPFoundation dependency by inlining what we need

### DIFF
--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,2 @@
-
-github "weichsel/ZIPFoundation" "0.9.5"
+#github "weichsel/ZIPFoundation" "0.9.5"
 

--- a/FlintCore.xcodeproj/project.pbxproj
+++ b/FlintCore.xcodeproj/project.pbxproj
@@ -95,6 +95,30 @@
 		492B2A4420FE9A2400F4EAB0 /* CompletionRequirement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 492B2A4220FE9A1B00F4EAB0 /* CompletionRequirement.swift */; };
 		492B2A4520FE9A2500F4EAB0 /* CompletionRequirement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 492B2A4220FE9A1B00F4EAB0 /* CompletionRequirement.swift */; };
 		492B2A4620FE9A2600F4EAB0 /* CompletionRequirement.swift in Sources */ = {isa = PBXBuildFile; fileRef = 492B2A4220FE9A1B00F4EAB0 /* CompletionRequirement.swift */; };
+		493267482142F7F200CC88CB /* FileManager+ZIP.swift in Sources */ = {isa = PBXBuildFile; fileRef = 493267472142F7F200CC88CB /* FileManager+ZIP.swift */; };
+		493267492142F7F200CC88CB /* FileManager+ZIP.swift in Sources */ = {isa = PBXBuildFile; fileRef = 493267472142F7F200CC88CB /* FileManager+ZIP.swift */; };
+		4932674A2142F7F200CC88CB /* FileManager+ZIP.swift in Sources */ = {isa = PBXBuildFile; fileRef = 493267472142F7F200CC88CB /* FileManager+ZIP.swift */; };
+		4932674B2142F7F200CC88CB /* FileManager+ZIP.swift in Sources */ = {isa = PBXBuildFile; fileRef = 493267472142F7F200CC88CB /* FileManager+ZIP.swift */; };
+		4932674D2142F87C00CC88CB /* Entry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4932674C2142F87C00CC88CB /* Entry.swift */; };
+		4932674E2142F87C00CC88CB /* Entry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4932674C2142F87C00CC88CB /* Entry.swift */; };
+		4932674F2142F87C00CC88CB /* Entry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4932674C2142F87C00CC88CB /* Entry.swift */; };
+		493267502142F87C00CC88CB /* Entry.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4932674C2142F87C00CC88CB /* Entry.swift */; };
+		493267522142FA0E00CC88CB /* Archive+Writing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 493267512142FA0E00CC88CB /* Archive+Writing.swift */; };
+		493267532142FA0E00CC88CB /* Archive+Writing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 493267512142FA0E00CC88CB /* Archive+Writing.swift */; };
+		493267542142FA0E00CC88CB /* Archive+Writing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 493267512142FA0E00CC88CB /* Archive+Writing.swift */; };
+		493267552142FA0E00CC88CB /* Archive+Writing.swift in Sources */ = {isa = PBXBuildFile; fileRef = 493267512142FA0E00CC88CB /* Archive+Writing.swift */; };
+		493267572142FA2B00CC88CB /* Archive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 493267562142FA2B00CC88CB /* Archive.swift */; };
+		493267582142FA2B00CC88CB /* Archive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 493267562142FA2B00CC88CB /* Archive.swift */; };
+		493267592142FA2B00CC88CB /* Archive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 493267562142FA2B00CC88CB /* Archive.swift */; };
+		4932675A2142FA2B00CC88CB /* Archive.swift in Sources */ = {isa = PBXBuildFile; fileRef = 493267562142FA2B00CC88CB /* Archive.swift */; };
+		4932675C2142FA4D00CC88CB /* Data+Serialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4932675B2142FA4D00CC88CB /* Data+Serialization.swift */; };
+		4932675D2142FA4D00CC88CB /* Data+Serialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4932675B2142FA4D00CC88CB /* Data+Serialization.swift */; };
+		4932675E2142FA4D00CC88CB /* Data+Serialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4932675B2142FA4D00CC88CB /* Data+Serialization.swift */; };
+		4932675F2142FA4D00CC88CB /* Data+Serialization.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4932675B2142FA4D00CC88CB /* Data+Serialization.swift */; };
+		493267612142FA6B00CC88CB /* Data+Compression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 493267602142FA6B00CC88CB /* Data+Compression.swift */; };
+		493267622142FA6B00CC88CB /* Data+Compression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 493267602142FA6B00CC88CB /* Data+Compression.swift */; };
+		493267632142FA6B00CC88CB /* Data+Compression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 493267602142FA6B00CC88CB /* Data+Compression.swift */; };
+		493267642142FA6B00CC88CB /* Data+Compression.swift in Sources */ = {isa = PBXBuildFile; fileRef = 493267602142FA6B00CC88CB /* Data+Compression.swift */; };
 		493572D41FC9D284003AD465 /* FeatureGroup.swift in Sources */ = {isa = PBXBuildFile; fileRef = 493572D31FC9D284003AD465 /* FeatureGroup.swift */; };
 		4946FAC0208D16750097E10E /* ActionsBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4946FABF208D16750097E10E /* ActionsBuilder.swift */; };
 		4946FAC1208D16750097E10E /* ActionsBuilder.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4946FABF208D16750097E10E /* ActionsBuilder.swift */; };
@@ -461,8 +485,6 @@
 		49891ECD209714BA00B9BCBF /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 49891ECB209714BA00B9BCBF /* LaunchScreen.storyboard */; };
 		49891ED4209715DA00B9BCBF /* FlintCore.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 49CCF0AA1F8BB1B200F7020E /* FlintCore.framework */; };
 		49891ED5209715DA00B9BCBF /* FlintCore.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 49CCF0AA1F8BB1B200F7020E /* FlintCore.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
-		49891ED8209715DA00B9BCBF /* ZIPFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 49DB63F7205BD55700B9EE5D /* ZIPFoundation.framework */; };
-		49891ED9209715DA00B9BCBF /* ZIPFoundation.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 49DB63F7205BD55700B9EE5D /* ZIPFoundation.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		498A894C2068FF5200457D66 /* TimelineFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 498A894B2068FF5200457D66 /* TimelineFeature.swift */; };
 		498A894D2068FF5200457D66 /* TimelineFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 498A894B2068FF5200457D66 /* TimelineFeature.swift */; };
 		498A894E2068FF5200457D66 /* TimelineFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 498A894B2068FF5200457D66 /* TimelineFeature.swift */; };
@@ -603,7 +625,6 @@
 		49D24B6120B308F700649BB4 /* URLMappingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D24B5A20B3054C00649BB4 /* URLMappingTests.swift */; };
 		49D447F51FEC69F900DBB352 /* Feature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D447F41FEC69F900DBB352 /* Feature.swift */; };
 		49D447F71FEC6AA800DBB352 /* ConditionalFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49D447F61FEC6AA800DBB352 /* ConditionalFeature.swift */; };
-		49DB63F8205BD55800B9EE5D /* ZIPFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 49DB63F7205BD55700B9EE5D /* ZIPFoundation.framework */; };
 		49DB63FA205BD6DB00B9EE5D /* DebugReportingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB63F9205BD6DB00B9EE5D /* DebugReportingTests.swift */; };
 		49DB63FB205BD6DB00B9EE5D /* DebugReportingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB63F9205BD6DB00B9EE5D /* DebugReportingTests.swift */; };
 		49DB63FC205BD6DB00B9EE5D /* DebugReportingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DB63F9205BD6DB00B9EE5D /* DebugReportingTests.swift */; };
@@ -686,8 +707,6 @@
 		49F6824520D2C0B200B02318 /* ActivityMetadataRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F6824320D2C0B200B02318 /* ActivityMetadataRepresentable.swift */; };
 		49F6824620D2C0B200B02318 /* ActivityMetadataRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F6824320D2C0B200B02318 /* ActivityMetadataRepresentable.swift */; };
 		49F6824720D2C0B200B02318 /* ActivityMetadataRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49F6824320D2C0B200B02318 /* ActivityMetadataRepresentable.swift */; };
-		49FC45F620A46E5E00679F97 /* ZIPFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 49FC45F520A46E5E00679F97 /* ZIPFoundation.framework */; };
-		49FC45F820A46E6C00679F97 /* ZIPFoundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 49FC45F720A46E6C00679F97 /* ZIPFoundation.framework */; };
 		49FC45FB20A46F0900679F97 /* URLRoutingResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4927FEE7208A362E00163576 /* URLRoutingResult.swift */; };
 		49FC45FC20A46F0900679F97 /* URLRoutingResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4927FEE7208A362E00163576 /* URLRoutingResult.swift */; };
 		49FC45FD20A46F0A00679F97 /* URLRoutingResult.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4927FEE7208A362E00163576 /* URLRoutingResult.swift */; };
@@ -757,7 +776,6 @@
 			dstSubfolderSpec = 10;
 			files = (
 				49891ED5209715DA00B9BCBF /* FlintCore.framework in Embed Frameworks */,
-				49891ED9209715DA00B9BCBF /* ZIPFoundation.framework in Embed Frameworks */,
 			);
 			name = "Embed Frameworks";
 			runOnlyForDeploymentPostprocessing = 0;
@@ -794,6 +812,12 @@
 		4929823B205ED12C00267A49 /* ActionMetadata.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionMetadata.swift; sourceTree = "<group>"; };
 		49298240205FCC6000267A49 /* ActionOutcome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionOutcome.swift; sourceTree = "<group>"; };
 		492B2A4220FE9A1B00F4EAB0 /* CompletionRequirement.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompletionRequirement.swift; sourceTree = "<group>"; };
+		493267472142F7F200CC88CB /* FileManager+ZIP.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "FileManager+ZIP.swift"; sourceTree = "<group>"; };
+		4932674C2142F87C00CC88CB /* Entry.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Entry.swift; sourceTree = "<group>"; };
+		493267512142FA0E00CC88CB /* Archive+Writing.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Archive+Writing.swift"; sourceTree = "<group>"; };
+		493267562142FA2B00CC88CB /* Archive.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Archive.swift; sourceTree = "<group>"; };
+		4932675B2142FA4D00CC88CB /* Data+Serialization.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Serialization.swift"; sourceTree = "<group>"; };
+		493267602142FA6B00CC88CB /* Data+Compression.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Data+Compression.swift"; sourceTree = "<group>"; };
 		493572D31FC9D284003AD465 /* FeatureGroup.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeatureGroup.swift; sourceTree = "<group>"; };
 		4946FABF208D16750097E10E /* ActionsBuilder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionsBuilder.swift; sourceTree = "<group>"; };
 		4946FAC4208E23740097E10E /* ActionPerformOutcome.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ActionPerformOutcome.swift; sourceTree = "<group>"; };
@@ -987,7 +1011,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				49FC45F620A46E5E00679F97 /* ZIPFoundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1005,7 +1028,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				49FC45F820A46E6C00679F97 /* ZIPFoundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1031,7 +1053,6 @@
 			files = (
 				49CC6630212332820042489F /* EventKit.framework in Frameworks */,
 				49891ED4209715DA00B9BCBF /* FlintCore.framework in Frameworks */,
-				49891ED8209715DA00B9BCBF /* ZIPFoundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1039,7 +1060,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				49DB63F8205BD55800B9EE5D /* ZIPFoundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -1074,6 +1094,19 @@
 				49298228205D67A100267A49 /* DummyFeature.swift */,
 			);
 			path = "Test Features";
+			sourceTree = "<group>";
+		};
+		493267462142F7A700CC88CB /* Zip */ = {
+			isa = PBXGroup;
+			children = (
+				493267472142F7F200CC88CB /* FileManager+ZIP.swift */,
+				4932674C2142F87C00CC88CB /* Entry.swift */,
+				493267512142FA0E00CC88CB /* Archive+Writing.swift */,
+				493267562142FA2B00CC88CB /* Archive.swift */,
+				4932675B2142FA4D00CC88CB /* Data+Serialization.swift */,
+				493267602142FA6B00CC88CB /* Data+Compression.swift */,
+			);
+			path = Zip;
 			sourceTree = "<group>";
 		};
 		494F59092098A9A90075E7EE /* Constraints */ = {
@@ -1315,6 +1348,7 @@
 		498B8084200120EB00E44C91 /* Utils */ = {
 			isa = PBXGroup;
 			children = (
+				493267462142F7A700CC88CB /* Zip */,
 				4914EFC62067C4D000FE0F41 /* Formatters.swift */,
 				497175FD20ECE00A00F88482 /* DynamicLibraryBinding.swift */,
 				498B80852001210300E44C91 /* String+Extensions.swift */,
@@ -1928,6 +1962,7 @@
 				496F8F80203EEBBA003AB29B /* ConditionalFeatureDefinition.swift in Sources */,
 				496F8F4B203EEBA5003AB29B /* AnalyticsReporting.swift in Sources */,
 				49FC45FB20A46F0900679F97 /* URLRoutingResult.swift in Sources */,
+				493267532142FA0E00CC88CB /* Archive+Writing.swift in Sources */,
 				496F8F4A203EEBA5003AB29B /* ObserverSet.swift in Sources */,
 				496F8F83203EEBBA003AB29B /* AvailabilityChecker.swift in Sources */,
 				496F8F54203EEBB1003AB29B /* Timeline.swift in Sources */,
@@ -1947,6 +1982,7 @@
 				49DFB7DF20A3464800D3AE68 /* FeaturePermissionRequirements.swift in Sources */,
 				4956D5DA209895C2002A2A35 /* UserFeatureTogglesObserver.swift in Sources */,
 				4921706620D27D14007D6883 /* FlintImage.swift in Sources */,
+				493267582142FA2B00CC88CB /* Archive.swift in Sources */,
 				49BC1C4620795E9E00A7FC77 /* LIFOArrayQueueDataSource.swift in Sources */,
 				494F59112098AA140075E7EE /* OperatingSystemVersion+Utilities.swift in Sources */,
 				494F590C2098A9F70075E7EE /* Platform.swift in Sources */,
@@ -1967,6 +2003,8 @@
 				49EA0BCF208B874900B9A32E /* SmartDispatchQueue.swift in Sources */,
 				4927FEF3208A3B8800163576 /* ActionSource.swift in Sources */,
 				496F8F9C203EEBC4003AB29B /* PresentationRouter.swift in Sources */,
+				493267492142F7F200CC88CB /* FileManager+ZIP.swift in Sources */,
+				4932674E2142F87C00CC88CB /* Entry.swift in Sources */,
 				496136C6209900E200291885 /* CameraPermissionAdapter.swift in Sources */,
 				499FE35420BD8BAE00552CE9 /* FeatureConstraintResult.swift in Sources */,
 				496136B7209900A700291885 /* SystemPermissionStatus.swift in Sources */,
@@ -1976,6 +2014,7 @@
 				494F59342098AB720075E7EE /* PurchasePreconditionEvaluator.swift in Sources */,
 				496F8FCE203EEBDA003AB29B /* Flint.swift in Sources */,
 				499FE34D20BD89F800552CE9 /* FeatureConstraint.swift in Sources */,
+				493267622142FA6B00CC88CB /* Data+Compression.swift in Sources */,
 				4924C6FE20A99B69005AD086 /* FeatureConstraintsBuilder+Extensions.swift in Sources */,
 				498F97742077846000209633 /* FocusArea.swift in Sources */,
 				496F8FC3203EEBDA003AB29B /* ActionRequest.swift in Sources */,
@@ -1994,6 +2033,7 @@
 				496F8F86203EEBBA003AB29B /* UserDefaultsFeatureToggles.swift in Sources */,
 				49BC1C4B20795EB800A7FC77 /* UniquelyIdentifiable.swift in Sources */,
 				49F6823B20D2BEF100B02318 /* ActivityMetadata.swift in Sources */,
+				4932675D2142FA4D00CC88CB /* Data+Serialization.swift in Sources */,
 				4921705520D13B31007D6883 /* ActivityBuilder.swift in Sources */,
 				496F8FAA203EEBD3003AB29B /* ActionURLMappings.swift in Sources */,
 				49FC460720A4793600679F97 /* FocusFeature.swift in Sources */,
@@ -2115,6 +2155,7 @@
 				496F8F89203EEBBB003AB29B /* ConditionalFeatureDefinition.swift in Sources */,
 				496F8F4E203EEBA6003AB29B /* AnalyticsReporting.swift in Sources */,
 				49FC45FC20A46F0900679F97 /* URLRoutingResult.swift in Sources */,
+				493267542142FA0E00CC88CB /* Archive+Writing.swift in Sources */,
 				496F8F4D203EEBA6003AB29B /* ObserverSet.swift in Sources */,
 				496F8F8C203EEBBB003AB29B /* AvailabilityChecker.swift in Sources */,
 				496F8F63203EEBB2003AB29B /* Timeline.swift in Sources */,
@@ -2134,6 +2175,7 @@
 				49DFB7E020A3464800D3AE68 /* FeaturePermissionRequirements.swift in Sources */,
 				4956D5DB209895C2002A2A35 /* UserFeatureTogglesObserver.swift in Sources */,
 				4921706720D27D14007D6883 /* FlintImage.swift in Sources */,
+				493267592142FA2B00CC88CB /* Archive.swift in Sources */,
 				49BC1C4720795E9E00A7FC77 /* LIFOArrayQueueDataSource.swift in Sources */,
 				494F59122098AA140075E7EE /* OperatingSystemVersion+Utilities.swift in Sources */,
 				494F590D2098A9F70075E7EE /* Platform.swift in Sources */,
@@ -2154,6 +2196,8 @@
 				49EA0BD0208B874900B9A32E /* SmartDispatchQueue.swift in Sources */,
 				4927FEF2208A3B8800163576 /* ActionSource.swift in Sources */,
 				496F8F9E203EEBC5003AB29B /* PresentationRouter.swift in Sources */,
+				4932674A2142F7F200CC88CB /* FileManager+ZIP.swift in Sources */,
+				4932674F2142F87C00CC88CB /* Entry.swift in Sources */,
 				496136C7209900E200291885 /* CameraPermissionAdapter.swift in Sources */,
 				499FE35520BD8BAE00552CE9 /* FeatureConstraintResult.swift in Sources */,
 				496136B8209900A700291885 /* SystemPermissionStatus.swift in Sources */,
@@ -2163,6 +2207,7 @@
 				494F59352098AB720075E7EE /* PurchasePreconditionEvaluator.swift in Sources */,
 				496F8FE3203EEBDA003AB29B /* Flint.swift in Sources */,
 				499FE34E20BD89F800552CE9 /* FeatureConstraint.swift in Sources */,
+				493267632142FA6B00CC88CB /* Data+Compression.swift in Sources */,
 				4924C6FF20A99B69005AD086 /* FeatureConstraintsBuilder+Extensions.swift in Sources */,
 				498F97752077846000209633 /* FocusArea.swift in Sources */,
 				496F8FD8203EEBDA003AB29B /* ActionRequest.swift in Sources */,
@@ -2181,6 +2226,7 @@
 				496F8F8F203EEBBB003AB29B /* UserDefaultsFeatureToggles.swift in Sources */,
 				49BC1C4C20795EB800A7FC77 /* UniquelyIdentifiable.swift in Sources */,
 				49F6823C20D2BEF100B02318 /* ActivityMetadata.swift in Sources */,
+				4932675E2142FA4D00CC88CB /* Data+Serialization.swift in Sources */,
 				4921705620D13B31007D6883 /* ActivityBuilder.swift in Sources */,
 				496F8FB2203EEBD4003AB29B /* ActionURLMappings.swift in Sources */,
 				49FC460820A4793700679F97 /* FocusFeature.swift in Sources */,
@@ -2302,6 +2348,7 @@
 				49FC460F20A488D000679F97 /* InternalJSONFormatting.swift in Sources */,
 				49DB92412073B4F600F758DC /* Product.swift in Sources */,
 				49298235205ED0D900267A49 /* FeatureActionsBuilder.swift in Sources */,
+				493267552142FA0E00CC88CB /* Archive+Writing.swift in Sources */,
 				49FC460320A46F3000679F97 /* LogEvent.swift in Sources */,
 				496F8FBE203EEBD4003AB29B /* URLMapping.swift in Sources */,
 				4946FAC8208E23740097E10E /* ActionPerformOutcome.swift in Sources */,
@@ -2321,6 +2368,7 @@
 				494F593B2098AB940075E7EE /* RuntimePreconditionEvaluator.swift in Sources */,
 				49935BCF206B901800CB2B5D /* ConditionalActionRequest.swift in Sources */,
 				4921706820D27D14007D6883 /* FlintImage.swift in Sources */,
+				4932675A2142FA2B00CC88CB /* Archive.swift in Sources */,
 				496F8F50203EEBA8003AB29B /* ObserverSet.swift in Sources */,
 				496F8F95203EEBBC003AB29B /* AvailabilityChecker.swift in Sources */,
 				496F8F72203EEBB2003AB29B /* Timeline.swift in Sources */,
@@ -2341,6 +2389,8 @@
 				496F8FF3203EEBDB003AB29B /* FeatureDefinition.swift in Sources */,
 				4927FF08208A556E00163576 /* ActivityEligibility.swift in Sources */,
 				496F8F71203EEBB2003AB29B /* ActionLoggingDispatchObserver.swift in Sources */,
+				4932674B2142F7F200CC88CB /* FileManager+ZIP.swift in Sources */,
+				493267502142F87C00CC88CB /* Entry.swift in Sources */,
 				49DB926320757D9500F758DC /* AnalyticsProvider.swift in Sources */,
 				499FE35620BD8BAE00552CE9 /* FeatureConstraintResult.swift in Sources */,
 				496F8F52203EEBA8003AB29B /* ConsoleAnalyticsProvider.swift in Sources */,
@@ -2350,6 +2400,7 @@
 				496F8F7B203EEBB3003AB29B /* LoggerOutput.swift in Sources */,
 				496F8FA0203EEBC5003AB29B /* PresentationRouter.swift in Sources */,
 				499FE34F20BD89F800552CE9 /* FeatureConstraint.swift in Sources */,
+				493267642142FA6B00CC88CB /* Data+Compression.swift in Sources */,
 				4924C70020A99B69005AD086 /* FeatureConstraintsBuilder+Extensions.swift in Sources */,
 				49F37A41209B2ACF00B27671 /* PlatformConstraint.swift in Sources */,
 				496F8F7E203EEBB3003AB29B /* PrintLoggerOutput.swift in Sources */,
@@ -2368,6 +2419,7 @@
 				496F8FF9203EEBDB003AB29B /* FlintFeatures.swift in Sources */,
 				49935BF2206D250400CB2B5D /* TimeOrderedResultsController.swift in Sources */,
 				49F6823D20D2BEF100B02318 /* ActivityMetadata.swift in Sources */,
+				4932675F2142FA4D00CC88CB /* Data+Serialization.swift in Sources */,
 				4921705720D13B31007D6883 /* ActivityBuilder.swift in Sources */,
 				4956D5DD209897AB002A2A35 /* PurchaseTrackerObserver.swift in Sources */,
 				496F8FA7203EEBCF003AB29B /* ActivitiesFeature.swift in Sources */,
@@ -2504,6 +2556,7 @@
 				49A999FA1FF7FA6700A64E8C /* AnalyticsReporting.swift in Sources */,
 				4976923B201F3CBE00F97BD5 /* URLMappingsBuilder.swift in Sources */,
 				49F6823F20D2C07100B02318 /* ActivityMetadataBuilder.swift in Sources */,
+				493267482142F7F200CC88CB /* FileManager+ZIP.swift in Sources */,
 				496136C5209900E200291885 /* CameraPermissionAdapter.swift in Sources */,
 				49CF4D3920F5281C0009FFF4 /* FlintLoggable.swift in Sources */,
 				495FD9FE200363290007A427 /* FeaturePath.swift in Sources */,
@@ -2512,6 +2565,8 @@
 				49935BEF206D250400CB2B5D /* TimeOrderedResultsController.swift in Sources */,
 				49A62C8820D2FF3B00264606 /* ActionActivityMappings.swift in Sources */,
 				49966D8F200A63D1004C4AA0 /* AvailabilityChecker.swift in Sources */,
+				493267612142FA6B00CC88CB /* Data+Compression.swift in Sources */,
+				4932675C2142FA4D00CC88CB /* Data+Serialization.swift in Sources */,
 				494F59332098AB720075E7EE /* PurchasePreconditionEvaluator.swift in Sources */,
 				4977DC73205ABF7400DAA0C8 /* InternalJSONFormatting.swift in Sources */,
 				49647D3B20384077005F9825 /* ActivitiesFeature.swift in Sources */,
@@ -2531,6 +2586,8 @@
 				496136C0209900CE00291885 /* SystemPermissionAdapter.swift in Sources */,
 				49653A3420F26DA400AFDDDB /* ContactsPermissionAdapter.swift in Sources */,
 				49819EB01FC9C1500013AF55 /* Action.swift in Sources */,
+				493267572142FA2B00CC88CB /* Archive.swift in Sources */,
+				493267522142FA0E00CC88CB /* Archive+Writing.swift in Sources */,
 				495B6C69202B60A50024CDFB /* FlintAppInfo.swift in Sources */,
 				4929823C205ED12C00267A49 /* ActionMetadata.swift in Sources */,
 				499FE34720BD89C400552CE9 /* FeatureConstraintEvaluationResults.swift in Sources */,
@@ -2548,6 +2605,7 @@
 				49935BD1206BA0DF00CB2B5D /* LogEventContext.swift in Sources */,
 				49298232205ED0D900267A49 /* FeatureActionsBuilder.swift in Sources */,
 				4921AC0F203729BB003465E5 /* DefaultContextSpecificLogger.swift in Sources */,
+				4932674D2142F87C00CC88CB /* Entry.swift in Sources */,
 				49A99A041FF906AA00A64E8C /* DefaultLoggerFactory.swift in Sources */,
 				49DFB7C520A2DF8500D3AE68 /* AuthorisationController.swift in Sources */,
 				49BC1C4520795E9E00A7FC77 /* LIFOArrayQueueDataSource.swift in Sources */,

--- a/FlintCore.xcodeproj/xcshareddata/xcschemes/FlintCore-iOS-Tests.xcscheme
+++ b/FlintCore.xcodeproj/xcshareddata/xcschemes/FlintCore-iOS-Tests.xcscheme
@@ -26,7 +26,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      enableThreadSanitizer = "YES"
       enableUBSanitizer = "YES"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>

--- a/FlintCore.xcodeproj/xcshareddata/xcschemes/FlintCore-iOS.xcscheme
+++ b/FlintCore.xcodeproj/xcshareddata/xcschemes/FlintCore-iOS.xcscheme
@@ -54,7 +54,6 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      enableThreadSanitizer = "YES"
       enableUBSanitizer = "YES"
       shouldUseLaunchSchemeArgsEnv = "YES">
       <Testables>
@@ -85,10 +84,12 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      enableThreadSanitizer = "YES"
       launchStyle = "0"
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      stopOnEveryThreadSanitizerIssue = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>

--- a/FlintCore/Debug Reporting/DebugReporting.swift
+++ b/FlintCore/Debug Reporting/DebugReporting.swift
@@ -7,7 +7,6 @@
 //
 
 import Foundation
-import ZIPFoundation
 
 /// A class for managing the debug reporting options of Flint.
 ///

--- a/FlintCore/Utils/Zip/Archive+Writing.swift
+++ b/FlintCore/Utils/Zip/Archive+Writing.swift
@@ -1,0 +1,329 @@
+//
+//  Archive+Writing.swift
+//  ZIPFoundation
+//
+//  Copyright © 2017 Thomas Zoechling, https://www.peakstep.com and the ZIP Foundation project authors.
+//  Released under the MIT License.
+//
+//  See https://github.com/weichsel/ZIPFoundation/blob/master/LICENSE for license information.
+//
+
+import Foundation
+
+extension Archive {
+    private enum ModifyOperation: Int {
+        case remove = -1
+        case add = 1
+    }
+
+    /// Write files, directories or symlinks to the receiver.
+    ///
+    /// - Parameters:
+    ///   - path: The path that is used to identify an `Entry` within the `Archive` file.
+    ///   - baseURL: The base URL of the `Entry` to add.
+    ///              The `baseURL` combined with `path` must form a fully qualified file URL.
+    ///   - compressionMethod: Indicates the `CompressionMethod` that should be applied to `Entry`.
+    ///   - bufferSize: The maximum size of the write buffer and the compression buffer (if needed).
+    ///   - progress: A progress object that can be used to track or cancel the add operation.
+    /// - Throws: An error if the source file cannot be read or the receiver is not writable.
+    public func addEntry(with path: String, relativeTo baseURL: URL, compressionMethod: CompressionMethod = .none,
+                         bufferSize: UInt32 = defaultWriteChunkSize, progress: Progress? = nil) throws {
+        let fileManager = FileManager()
+        let entryURL = baseURL.appendingPathComponent(path)
+        guard fileManager.fileExists(atPath: entryURL.path) else {
+            throw CocoaError.error(.fileReadNoSuchFile, userInfo: [NSFilePathErrorKey: entryURL.path], url: nil)
+        }
+        guard fileManager.isReadableFile(atPath: entryURL.path) else {
+            throw CocoaError.error(.fileReadNoPermission, userInfo: [NSFilePathErrorKey: url.path], url: nil)
+        }
+        let type = try FileManager.typeForItem(at: entryURL)
+        let modDate = try FileManager.fileModificationDateTimeForItem(at: entryURL)
+        let uncompressedSize = type == .directory ? 0 : try FileManager.fileSizeForItem(at: entryURL)
+        let permissions = try FileManager.permissionsForItem(at: entryURL)
+        var provider: Provider
+        switch type {
+        case .file:
+            let entryFileSystemRepresentation = fileManager.fileSystemRepresentation(withPath: entryURL.path)
+            let entryFile: UnsafeMutablePointer<FILE> = fopen(entryFileSystemRepresentation, "rb")
+            defer { fclose(entryFile) }
+            provider = { _, _ in return try Data.readChunk(of: Int(bufferSize), from: entryFile) }
+            try self.addEntry(with: path, type: type, uncompressedSize: uncompressedSize,
+                              modificationDate: modDate, permissions: permissions,
+                              compressionMethod: compressionMethod, bufferSize: bufferSize,
+                              progress: progress, provider: provider)
+        case .directory:
+            provider = { _, _ in return Data() }
+            try self.addEntry(with: path.hasSuffix("/") ? path : path + "/",
+                              type: type, uncompressedSize: uncompressedSize,
+                              modificationDate: modDate, permissions: permissions,
+                              compressionMethod: compressionMethod, bufferSize: bufferSize,
+                              progress: progress, provider: provider)
+        case .symlink:
+            provider = { _, _ -> Data in
+                let fileManager = FileManager()
+                let linkDestination = try fileManager.destinationOfSymbolicLink(atPath: entryURL.path)
+                let linkFileSystemRepresentation = fileManager.fileSystemRepresentation(withPath: linkDestination)
+                let linkLength = Int(strlen(linkFileSystemRepresentation))
+                let linkBuffer = UnsafeBufferPointer(start: linkFileSystemRepresentation, count: linkLength)
+                return Data.init(buffer: linkBuffer)
+            }
+            try self.addEntry(with: path, type: type, uncompressedSize: uncompressedSize,
+                              modificationDate: modDate, permissions: permissions,
+                              compressionMethod: compressionMethod, bufferSize: bufferSize,
+                              progress: progress, provider: provider)
+        }
+    }
+
+    /// Write files, directories or symlinks to the receiver.
+    ///
+    /// - Parameters:
+    ///   - path: The path that is used to identify an `Entry` within the `Archive` file.
+    ///   - type: Indicates the `Entry.EntryType` of the added content.
+    ///   - uncompressedSize: The uncompressed size of the data that is going to be added with `provider`.
+    ///   - modificationDate: A `Date` describing the file modification date of the `Entry`.
+    ///                       Default is the current `Date`.
+    ///   - permissions: POSIX file permissions for the `Entry`.
+    ///                  Default is `0`o`644` for files and symlinks and `0`o`755` for directories.
+    ///   - compressionMethod: Indicates the `CompressionMethod` that should be applied to `Entry`.
+    ///   - bufferSize: The maximum size of the write buffer and the compression buffer (if needed).
+    ///   - progress: A progress object that can be used to track or cancel the add operation.
+    ///   - provider: A closure that accepts a position and a chunk size. Returns a `Data` chunk.
+    /// - Throws: An error if the source data is invalid or the receiver is not writable.
+    public func addEntry(with path: String, type: Entry.EntryType, uncompressedSize: UInt32,
+                         modificationDate: Date = Date(), permissions: UInt16? = nil,
+                         compressionMethod: CompressionMethod = .none, bufferSize: UInt32 = defaultWriteChunkSize,
+                         progress: Progress? = nil, provider: Provider) throws {
+        guard self.accessMode != .read else { throw ArchiveError.unwritableArchive }
+        progress?.totalUnitCount = type == .directory ? defaultDirectoryUnitCount : Int64(uncompressedSize)
+        var endOfCentralDirRecord = self.endOfCentralDirectoryRecord
+        var startOfCD = Int(endOfCentralDirRecord.offsetToStartOfCentralDirectory)
+        var existingCentralDirData = Data()
+        fseek(self.archiveFile, startOfCD, SEEK_SET)
+        existingCentralDirData = try Data.readChunk(of: Int(endOfCentralDirRecord.sizeOfCentralDirectory),
+                                                    from: self.archiveFile)
+        fseek(self.archiveFile, startOfCD, SEEK_SET)
+        let localFileHeaderStart = ftell(self.archiveFile)
+        let modDateTime = modificationDate.fileModificationDateTime
+        defer { fflush(self.archiveFile) }
+        do {
+            var localFileHeader = try self.writeLocalFileHeader(path: path, compressionMethod: compressionMethod,
+                                                                size: (uncompressedSize, 0), checksum: 0,
+                                                                modificationDateTime: modDateTime)
+            let (written, checksum) = try self.writeEntry(localFileHeader: localFileHeader, type: type,
+                                                          compressionMethod: compressionMethod, bufferSize: bufferSize,
+                                                          progress: progress, provider: provider)
+            startOfCD = ftell(self.archiveFile)
+            fseek(self.archiveFile, localFileHeaderStart, SEEK_SET)
+            // Write the local file header a second time. Now with compressedSize (if applicable) and a valid checksum.
+            localFileHeader = try self.writeLocalFileHeader(path: path, compressionMethod: compressionMethod,
+                                                            size: (uncompressedSize, written),
+                                                            checksum: checksum, modificationDateTime: modDateTime)
+            fseek(self.archiveFile, startOfCD, SEEK_SET)
+            _ = try Data.write(chunk: existingCentralDirData, to: self.archiveFile)
+            let permissions = permissions ?? (type == .directory ? defaultDirectoryPermissions :defaultFilePermissions)
+            let externalAttributes = FileManager.externalFileAttributesForEntry(of: type, permissions: permissions)
+            let offset = UInt32(localFileHeaderStart)
+            let centralDir = try self.writeCentralDirectoryStructure(localFileHeader: localFileHeader,
+                                                                     relativeOffset: offset,
+                                                                     externalFileAttributes: externalAttributes)
+            if startOfCD > UINT32_MAX { throw ArchiveError.invalidStartOfCentralDirectoryOffset }
+            endOfCentralDirRecord = try self.writeEndOfCentralDirectory(centralDirectoryStructure: centralDir,
+                                                                        startOfCentralDirectory: UInt32(startOfCD),
+                                                                        operation: .add)
+            self.endOfCentralDirectoryRecord = endOfCentralDirRecord
+        } catch ArchiveError.cancelledOperation {
+            try rollback(localFileHeaderStart, existingCentralDirData, endOfCentralDirRecord)
+            throw ArchiveError.cancelledOperation
+        }
+    }
+
+    /// Remove a ZIP `Entry` from the receiver.
+    ///
+    /// - Parameters:
+    ///   - entry: The `Entry` to remove.
+    ///   - bufferSize: The maximum size for the read and write buffers used during removal.
+    ///   - progress: A progress object that can be used to track or cancel the remove operation.
+    /// - Throws: An error if the `Entry` is malformed or the receiver is not writable.
+    public func remove(_ entry: Entry, bufferSize: UInt32 = defaultReadChunkSize, progress: Progress? = nil) throws {
+        let uniqueString = ProcessInfo.processInfo.globallyUniqueString
+        let tempArchiveURL =  URL(fileURLWithPath: NSTemporaryDirectory()).appendingPathComponent(uniqueString)
+        guard let tempArchive = Archive(url: tempArchiveURL, accessMode: .create) else {
+            throw ArchiveError.unwritableArchive
+        }
+        progress?.totalUnitCount = self.totalUnitCountForRemoving(entry)
+        var centralDirectoryData = Data()
+        var offset = 0
+        for currentEntry in self {
+            let centralDirectoryStructure = currentEntry.centralDirectoryStructure
+            if currentEntry != entry {
+                let entryStart = Int(currentEntry.centralDirectoryStructure.relativeOffsetOfLocalHeader)
+                fseek(self.archiveFile, entryStart, SEEK_SET)
+                let provider: Provider = { (_, chunkSize) -> Data in
+                    if progress?.isCancelled == true { throw ArchiveError.cancelledOperation }
+                    return try Data.readChunk(of: Int(chunkSize), from: self.archiveFile)
+                }
+                let consumer: Consumer = {
+                    _ = try Data.write(chunk: $0, to: tempArchive.archiveFile)
+                    progress?.completedUnitCount += Int64($0.count)
+                }
+                _ = try Data.consumePart(of: Int(currentEntry.localSize), chunkSize: Int(bufferSize),
+                                         provider: provider, consumer: consumer)
+                let centralDir = CentralDirectoryStructure(centralDirectoryStructure: centralDirectoryStructure,
+                                                           offset: UInt32(offset))
+                centralDirectoryData.append(centralDir.data)
+            } else { offset = currentEntry.localSize }
+        }
+        let startOfCentralDirectory = ftell(tempArchive.archiveFile)
+        _ = try Data.write(chunk: centralDirectoryData, to: tempArchive.archiveFile)
+        tempArchive.endOfCentralDirectoryRecord = self.endOfCentralDirectoryRecord
+        let endOfCentralDirectoryRecord = try
+            tempArchive.writeEndOfCentralDirectory(centralDirectoryStructure: entry.centralDirectoryStructure,
+                                                   startOfCentralDirectory: UInt32(startOfCentralDirectory),
+                                                   operation: .remove)
+        tempArchive.endOfCentralDirectoryRecord = endOfCentralDirectoryRecord
+        self.endOfCentralDirectoryRecord = endOfCentralDirectoryRecord
+        fflush(tempArchive.archiveFile)
+        try self.replaceCurrentArchiveWithArchive(at: tempArchive.url)
+    }
+
+    // MARK: - Helpers
+
+    private func writeLocalFileHeader(path: String, compressionMethod: CompressionMethod,
+                                      size: (uncompressed: UInt32, compressed: UInt32),
+                                      checksum: CRC32,
+                                      modificationDateTime: (UInt16, UInt16)) throws -> LocalFileHeader {
+        let fileManager = FileManager()
+        let fileSystemRepresentation = fileManager.fileSystemRepresentation(withPath: path)
+        let fileNameLength = Int(strlen(fileSystemRepresentation))
+        let fileNameBuffer = UnsafeBufferPointer(start: fileSystemRepresentation, count: fileNameLength)
+        let fileNameData = Data.init(buffer: fileNameBuffer)
+        let localFileHeader = LocalFileHeader(versionNeededToExtract: UInt16(20), generalPurposeBitFlag: UInt16(2048),
+                                              compressionMethod: compressionMethod.rawValue,
+                                              lastModFileTime: modificationDateTime.1,
+                                              lastModFileDate: modificationDateTime.0, crc32: checksum,
+                                              compressedSize: size.compressed, uncompressedSize: size.uncompressed,
+                                              fileNameLength: UInt16(fileNameLength), extraFieldLength: UInt16(0),
+                                              fileNameData: fileNameData, extraFieldData: Data())
+        _ = try Data.write(chunk: localFileHeader.data, to: self.archiveFile)
+        return localFileHeader
+    }
+
+    private func writeEntry(localFileHeader: LocalFileHeader, type: Entry.EntryType,
+                            compressionMethod: CompressionMethod, bufferSize: UInt32, progress: Progress? = nil,
+                            provider: Provider) throws -> (sizeWritten: UInt32, crc32: CRC32) {
+        var checksum = CRC32(0)
+        var sizeWritten = UInt32(0)
+        switch type {
+        case .file:
+            switch compressionMethod {
+            case .none:
+                (sizeWritten, checksum) = try self.writeUncompressed(size: localFileHeader.uncompressedSize,
+                                                                     bufferSize: bufferSize,
+                                                                     progress: progress, provider: provider)
+            case .deflate:
+                (sizeWritten, checksum) = try self.writeCompressed(size: localFileHeader.uncompressedSize,
+                                                                   bufferSize: bufferSize,
+                                                                   progress: progress, provider: provider)
+            }
+        case .directory:
+            _ = try provider(0, 0)
+            if let progress = progress { progress.completedUnitCount = progress.totalUnitCount }
+        case .symlink:
+            (sizeWritten, checksum) = try self.writeSymbolicLink(size: localFileHeader.uncompressedSize,
+                                                                 provider: provider)
+            if let progress = progress { progress.completedUnitCount = progress.totalUnitCount }
+        }
+        return (sizeWritten, checksum)
+    }
+
+    private func writeUncompressed(size: UInt32, bufferSize: UInt32, progress: Progress? = nil,
+                                   provider: Provider) throws -> (sizeWritten: UInt32, checksum: CRC32) {
+        var position = 0
+        var sizeWritten = 0
+        var checksum = CRC32(0)
+        while position < size {
+            if progress?.isCancelled == true { throw ArchiveError.cancelledOperation }
+            let readSize = (Int(size) - position) >= bufferSize ? Int(bufferSize) : (Int(size) - position)
+            let entryChunk = try provider(Int(position), Int(readSize))
+            checksum = entryChunk.crc32(checksum: checksum)
+            sizeWritten += try Data.write(chunk: entryChunk, to: self.archiveFile)
+            position += Int(bufferSize)
+            progress?.completedUnitCount = Int64(sizeWritten)
+        }
+        return (UInt32(sizeWritten), checksum)
+    }
+
+    private func writeCompressed(size: UInt32, bufferSize: UInt32, progress: Progress? = nil,
+                                 provider: Provider) throws -> (sizeWritten: UInt32, checksum: CRC32) {
+        var sizeWritten = 0
+        let consumer: Consumer = { data in sizeWritten += try Data.write(chunk: data, to: self.archiveFile) }
+        let checksum = try Data.compress(size: Int(size), bufferSize: Int(bufferSize),
+                                         provider: { (position, size) -> Data in
+                                            if progress?.isCancelled == true { throw ArchiveError.cancelledOperation }
+                                            let data = try provider(position, size)
+                                            progress?.completedUnitCount += Int64(data.count)
+                                            return data
+                                         }, consumer: consumer)
+        return(UInt32(sizeWritten), checksum)
+    }
+
+    private func writeSymbolicLink(size: UInt32, provider: Provider) throws -> (sizeWritten: UInt32, checksum: CRC32) {
+        let linkData = try provider(0, Int(size))
+        let checksum = linkData.crc32(checksum: 0)
+        let sizeWritten = try Data.write(chunk: linkData, to: self.archiveFile)
+        return (UInt32(sizeWritten), checksum)
+    }
+
+    private func writeCentralDirectoryStructure(localFileHeader: LocalFileHeader, relativeOffset: UInt32,
+                                                externalFileAttributes: UInt32) throws -> CentralDirectoryStructure {
+        let centralDirectory = CentralDirectoryStructure(localFileHeader: localFileHeader,
+                                                         fileAttributes: externalFileAttributes,
+                                                         relativeOffset: relativeOffset)
+        _ = try Data.write(chunk: centralDirectory.data, to: self.archiveFile)
+        return centralDirectory
+    }
+
+    private func writeEndOfCentralDirectory(centralDirectoryStructure: CentralDirectoryStructure,
+                                            startOfCentralDirectory: UInt32,
+                                            operation: ModifyOperation) throws -> EndOfCentralDirectoryRecord {
+        var record = self.endOfCentralDirectoryRecord
+        let countChange = operation.rawValue
+        var dataLength = centralDirectoryStructure.extraFieldLength
+        dataLength += centralDirectoryStructure.fileNameLength
+        dataLength += centralDirectoryStructure.fileCommentLength
+        let centralDirectoryDataLengthChange = operation.rawValue * (Int(dataLength) + CentralDirectoryStructure.size)
+        var updatedSizeOfCentralDirectory = Int(record.sizeOfCentralDirectory)
+        updatedSizeOfCentralDirectory += centralDirectoryDataLengthChange
+        let numberOfEntriesOnDisk = UInt16(Int(record.totalNumberOfEntriesOnDisk) + countChange)
+        let numberOfEntriesInCentralDirectory = UInt16(Int(record.totalNumberOfEntriesInCentralDirectory) + countChange)
+        record = EndOfCentralDirectoryRecord(record: record, numberOfEntriesOnDisk: numberOfEntriesOnDisk,
+                                             numberOfEntriesInCentralDirectory: numberOfEntriesInCentralDirectory,
+                                             updatedSizeOfCentralDirectory: UInt32(updatedSizeOfCentralDirectory),
+                                             startOfCentralDirectory: startOfCentralDirectory)
+        _ = try Data.write(chunk: record.data, to: self.archiveFile)
+        return record
+    }
+
+    private func rollback(_ localFileHeaderStart: Int,
+                          _ existingCentralDirectoryData: Data,
+                          _ endOfCentralDirRecord: EndOfCentralDirectoryRecord) throws {
+        fflush(self.archiveFile)
+        ftruncate(fileno(self.archiveFile), off_t(localFileHeaderStart))
+        fseek(self.archiveFile, localFileHeaderStart, SEEK_SET)
+        _ = try Data.write(chunk: existingCentralDirectoryData, to: self.archiveFile)
+        _ = try Data.write(chunk: endOfCentralDirRecord.data, to: self.archiveFile)
+    }
+
+    private func replaceCurrentArchiveWithArchive(at URL: URL) throws {
+        fclose(self.archiveFile)
+        let fileManager = FileManager()
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+            _ = try fileManager.replaceItemAt(self.url, withItemAt: URL)
+        #else
+            _ = try fileManager.removeItem(at: self.url)
+            _ = try fileManager.moveItem(at: URL, to: self.url)
+        #endif
+        let fileSystemRepresentation = fileManager.fileSystemRepresentation(withPath: self.url.path)
+        self.archiveFile = fopen(fileSystemRepresentation, "rb+")
+    }
+}

--- a/FlintCore/Utils/Zip/Archive.swift
+++ b/FlintCore/Utils/Zip/Archive.swift
@@ -1,0 +1,355 @@
+//
+//  Archive.swift
+//  ZIPFoundation
+//
+//  Copyright © 2017 Thomas Zoechling, https://www.peakstep.com and the ZIP Foundation project authors.
+//  Released under the MIT License.
+//
+//  See https://github.com/weichsel/ZIPFoundation/blob/master/LICENSE for license information.
+//
+
+import Foundation
+
+/// The default chunk size when reading entry data from an archive.
+public let defaultReadChunkSize = UInt32(16*1024)
+/// The default chunk size when writing entry data to an archive.
+public let defaultWriteChunkSize = defaultReadChunkSize
+/// The default permissions for newly added entries.
+public let defaultFilePermissions = UInt16(0o644)
+public let defaultDirectoryPermissions = UInt16(0o755)
+let defaultPOSIXBufferSize = defaultReadChunkSize
+let defaultDirectoryUnitCount = Int64(1)
+let minDirectoryEndOffset = 22
+let maxDirectoryEndOffset = 66000
+let endOfCentralDirectoryStructSignature = 0x06054b50
+let localFileHeaderStructSignature = 0x04034b50
+let dataDescriptorStructSignature = 0x08074b50
+let centralDirectoryStructSignature = 0x02014b50
+
+/// The compression method of an `Entry` in a ZIP `Archive`.
+public enum CompressionMethod: UInt16 {
+    /// Indicates that an `Entry` has no compression applied to its contents.
+    case none = 0
+    /// Indicates that contents of an `Entry` have been compressed with a zlib compatible Deflate algorithm.
+    case deflate = 8
+}
+
+/// A sequence of uncompressed or compressed ZIP entries.
+///
+/// You use an `Archive` to create, read or update ZIP files.
+/// To read an existing ZIP file, you have to pass in an existing file `URL` and `AccessMode.read`:
+///
+///     var archiveURL = URL(fileURLWithPath: "/path/file.zip")
+///     var archive = Archive(url: archiveURL, accessMode: .read)
+///
+/// An `Archive` is a sequence of entries. You can
+/// iterate over an archive using a `for`-`in` loop to get access to individual `Entry` objects:
+///
+///     for entry in archive {
+///         print(entry.path)
+///     }
+///
+/// Each `Entry` in an `Archive` is represented by its `path`. You can
+/// use `path` to retrieve the corresponding `Entry` from an `Archive` via subscripting:
+///
+///     let entry = archive['/path/file.txt']
+///
+/// To create a new `Archive`, pass in a non-existing file URL and `AccessMode.create`. To modify an
+/// existing `Archive` use `AccessMode.update`:
+///
+///     var archiveURL = URL(fileURLWithPath: "/path/file.zip")
+///     var archive = Archive(url: archiveURL, accessMode: .update)
+///     try archive?.addEntry("test.txt", relativeTo: baseURL, compressionMethod: .deflate)
+public final class Archive: Sequence {
+    typealias LocalFileHeader = Entry.LocalFileHeader
+    typealias DataDescriptor = Entry.DataDescriptor
+    typealias CentralDirectoryStructure = Entry.CentralDirectoryStructure
+
+    /// An error that occurs during reading, creating or updating a ZIP file.
+    public enum ArchiveError: Error {
+        /// Thrown when an archive file is either damaged or inaccessible.
+        case unreadableArchive
+        /// Thrown when an archive is either opened with AccessMode.read or the destination file is unwritable.
+        case unwritableArchive
+        /// Thrown when the path of an `Entry` cannot be stored in an archive.
+        case invalidEntryPath
+        /// Thrown when an `Entry` can't be stored in the archive with the proposed compression method.
+        case invalidCompressionMethod
+        /// Thrown when the start of the central directory exceeds `UINT32_MAX`
+        case invalidStartOfCentralDirectoryOffset
+        /// Thrown when an archive does not contain the required End of Central Directory Record.
+        case missingEndOfCentralDirectoryRecord
+        /// Thrown when an extract, add or remove operation was canceled.
+        case cancelledOperation
+    }
+
+    /// The access mode for an `Archive`.
+    public enum AccessMode: UInt {
+        /// Indicates that a newly instantiated `Archive` should create its backing file.
+        case create
+        /// Indicates that a newly instantiated `Archive` should read from an existing backing file.
+        case read
+        /// Indicates that a newly instantiated `Archive` should update an existing backing file.
+        case update
+    }
+
+    struct EndOfCentralDirectoryRecord: DataSerializable {
+        let endOfCentralDirectorySignature = UInt32(endOfCentralDirectoryStructSignature)
+        let numberOfDisk: UInt16
+        let numberOfDiskStart: UInt16
+        let totalNumberOfEntriesOnDisk: UInt16
+        let totalNumberOfEntriesInCentralDirectory: UInt16
+        let sizeOfCentralDirectory: UInt32
+        let offsetToStartOfCentralDirectory: UInt32
+        let zipFileCommentLength: UInt16
+        let zipFileCommentData: Data
+        static let size = 22
+    }
+
+    /// URL of an Archive's backing file.
+    public let url: URL
+    /// Access mode for an archive file.
+    public let accessMode: AccessMode
+    var archiveFile: UnsafeMutablePointer<FILE>
+    var endOfCentralDirectoryRecord: EndOfCentralDirectoryRecord
+
+    /// Initializes a new ZIP `Archive`.
+    ///
+    /// You can use this initalizer to create new archive files or to read and update existing ones.
+    ///
+    /// To read existing ZIP files, pass in an existing file URL and `AccessMode.read`.
+    ///
+    /// To create a new ZIP file, pass in a non-existing file URL and `AccessMode.create`.
+    ///
+    /// To update an existing ZIP file, pass in an existing file URL and `AccessMode.update`.
+    ///
+    /// - Parameters:
+    ///   - url: File URL to the receivers backing file.
+    ///   - mode: Access mode of the receiver.
+    ///
+    /// - Returns: An archive initialized with a backing file at the passed in file URL and the given access mode
+    ///   or `nil` if the following criteria are not met:
+    ///   - The file URL _must_ point to an existing file for `AccessMode.read`
+    ///   - The file URL _must_ point to a non-existing file for `AccessMode.write`
+    ///   - The file URL _must_ point to an existing file for `AccessMode.update`
+    public init?(url: URL, accessMode mode: AccessMode) {
+        self.url = url
+        self.accessMode = mode
+        let fileManager = FileManager()
+        switch mode {
+        case .read:
+            guard fileManager.fileExists(atPath: url.path) else { return nil }
+            guard fileManager.isReadableFile(atPath: url.path) else { return nil }
+            let fileSystemRepresentation = fileManager.fileSystemRepresentation(withPath: url.path)
+            self.archiveFile = fopen(fileSystemRepresentation, "rb")
+            guard let endOfCentralDirectoryRecord = Archive.scanForEndOfCentralDirectoryRecord(in: archiveFile) else {
+                return nil
+            }
+            self.endOfCentralDirectoryRecord = endOfCentralDirectoryRecord
+        case .create:
+            guard !fileManager.fileExists(atPath: url.path) else { return nil }
+            let endOfCentralDirectoryRecord = EndOfCentralDirectoryRecord(numberOfDisk: 0, numberOfDiskStart: 0,
+                                                                          totalNumberOfEntriesOnDisk: 0,
+                                                                          totalNumberOfEntriesInCentralDirectory: 0,
+                                                                          sizeOfCentralDirectory: 0,
+                                                                          offsetToStartOfCentralDirectory: 0,
+                                                                          zipFileCommentLength: 0,
+                                                                          zipFileCommentData: Data())
+            guard fileManager.createFile(atPath: url.path, contents: endOfCentralDirectoryRecord.data,
+                                         attributes: nil) else { return nil }
+            fallthrough
+        case .update:
+            guard fileManager.isWritableFile(atPath: url.path) else { return nil }
+            let fileSystemRepresentation = fileManager.fileSystemRepresentation(withPath: url.path)
+            self.archiveFile = fopen(fileSystemRepresentation, "rb+")
+            guard let endOfCentralDirectoryRecord = Archive.scanForEndOfCentralDirectoryRecord(in: archiveFile) else {
+                return nil
+            }
+            self.endOfCentralDirectoryRecord = endOfCentralDirectoryRecord
+            fseek(self.archiveFile, 0, SEEK_SET)
+        }
+        setvbuf(self.archiveFile, nil, _IOFBF, Int(defaultPOSIXBufferSize))
+    }
+
+    deinit {
+        fclose(self.archiveFile)
+    }
+
+    public func makeIterator() -> AnyIterator<Entry> {
+        let endOfCentralDirectoryRecord = self.endOfCentralDirectoryRecord
+        var directoryIndex = Int(endOfCentralDirectoryRecord.offsetToStartOfCentralDirectory)
+        var index = 0
+        return AnyIterator {
+            guard index < Int(endOfCentralDirectoryRecord.totalNumberOfEntriesInCentralDirectory) else { return nil }
+            guard let centralDirStruct: CentralDirectoryStructure = Data.readStruct(from: self.archiveFile,
+                                                                                    at: directoryIndex) else {
+                                                                                        return nil
+            }
+            let offset = Int(centralDirStruct.relativeOffsetOfLocalHeader)
+            guard let localFileHeader: LocalFileHeader = Data.readStruct(from: self.archiveFile,
+                                                                         at: offset) else { return nil }
+            var dataDescriptor: DataDescriptor? = nil
+            if centralDirStruct.usesDataDescriptor {
+                let additionalSize = Int(localFileHeader.fileNameLength + localFileHeader.extraFieldLength)
+                let isCompressed = centralDirStruct.compressionMethod != CompressionMethod.none.rawValue
+                let dataSize = isCompressed ? centralDirStruct.compressedSize : centralDirStruct.uncompressedSize
+                let descriptorPosition = offset + LocalFileHeader.size + additionalSize + Int(dataSize)
+                dataDescriptor = Data.readStruct(from: self.archiveFile, at: descriptorPosition)
+            }
+            defer {
+                directoryIndex += CentralDirectoryStructure.size
+                directoryIndex += Int(centralDirStruct.fileNameLength)
+                directoryIndex += Int(centralDirStruct.extraFieldLength)
+                directoryIndex += Int(centralDirStruct.fileCommentLength)
+                index += 1
+            }
+            return Entry(centralDirectoryStructure: centralDirStruct,
+                         localFileHeader: localFileHeader, dataDescriptor: dataDescriptor)
+        }
+    }
+
+    /// Retrieve the ZIP `Entry` with the given `path` from the receiver.
+    ///
+    /// - Note: The ZIP file format specification does not enforce unique paths for entries.
+    ///   Therefore an archive can contain multiple entries with the same path. This method
+    ///   always returns the first `Entry` with the given `path`.
+    ///
+    /// - Parameter path: A relative file path identifiying the corresponding `Entry`.
+    /// - Returns: An `Entry` with the given `path`. Otherwise, `nil`.
+    public subscript(path: String) -> Entry? {
+        return self.filter { $0.path == path }.first
+    }
+
+    // MARK: - Helpers
+
+    private static func scanForEndOfCentralDirectoryRecord(in file: UnsafeMutablePointer<FILE>)
+        -> EndOfCentralDirectoryRecord? {
+        var directoryEnd = 0
+        var index = minDirectoryEndOffset
+        var fileStat = stat()
+        fstat(fileno(file), &fileStat)
+        let archiveLength = Int(fileStat.st_size)
+        while directoryEnd == 0 && index < maxDirectoryEndOffset && index <= archiveLength {
+            fseek(file, archiveLength - index, SEEK_SET)
+            var potentialDirectoryEndTag: UInt32 = UInt32()
+            fread(&potentialDirectoryEndTag, 1, MemoryLayout<UInt32>.size, file)
+            if potentialDirectoryEndTag == UInt32(endOfCentralDirectoryStructSignature) {
+                directoryEnd = archiveLength - index
+                return Data.readStruct(from: file, at: directoryEnd)
+            }
+            index += 1
+        }
+        return nil
+    }
+}
+
+extension Archive {
+    /// The number of the work units that have to be performed when
+    /// removing `entry` from the receiver.
+    ///
+    /// - Parameter entry: The entry that will be removed.
+    /// - Returns: The number of the work units.
+    public func totalUnitCountForRemoving(_ entry: Entry) -> Int64 {
+        return Int64(self.endOfCentralDirectoryRecord.offsetToStartOfCentralDirectory
+                   - UInt32(entry.localSize))
+    }
+
+    func makeProgressForRemoving(_ entry: Entry) -> Progress {
+        return Progress(totalUnitCount: self.totalUnitCountForRemoving(entry))
+    }
+
+    /// The number of the work units that have to be performed when
+    /// reading `entry` from the receiver.
+    ///
+    /// - Parameter entry: The entry that will be read.
+    /// - Returns: The number of the work units.
+    public func totalUnitCountForReading(_ entry: Entry) -> Int64 {
+        switch entry.type {
+        case .file, .symlink:
+            return Int64(entry.uncompressedSize)
+        case .directory:
+            return defaultDirectoryUnitCount
+        }
+    }
+
+    func makeProgressForReading(_ entry: Entry) -> Progress {
+        return Progress(totalUnitCount: self.totalUnitCountForReading(entry))
+    }
+
+    /// The number of the work units that have to be performed when
+    /// adding the file at `url` to the receiver.
+    /// - Parameter entry: The entry that will be removed.
+    /// - Returns: The number of the work units.
+    public func totalUnitCountForAddingItem(at url: URL) -> Int64 {
+        var count = Int64(0)
+        do {
+            let type = try FileManager.typeForItem(at: url)
+            switch type {
+            case .file, .symlink:
+                count = Int64(try FileManager.fileSizeForItem(at: url))
+            case .directory:
+                count = defaultDirectoryUnitCount
+            }
+        } catch {
+            count = -1
+        }
+        return count
+    }
+
+    func makeProgressForAddingItem(at url: URL) -> Progress {
+        return Progress(totalUnitCount: self.totalUnitCountForAddingItem(at: url))
+    }
+}
+
+extension Archive.EndOfCentralDirectoryRecord {
+    var data: Data {
+        var endOfCentralDirectorySignature = self.endOfCentralDirectorySignature
+        var numberOfDisk = self.numberOfDisk
+        var numberOfDiskStart = self.numberOfDiskStart
+        var totalNumberOfEntriesOnDisk = self.totalNumberOfEntriesOnDisk
+        var totalNumberOfEntriesInCentralDirectory = self.totalNumberOfEntriesInCentralDirectory
+        var sizeOfCentralDirectory = self.sizeOfCentralDirectory
+        var offsetToStartOfCentralDirectory = self.offsetToStartOfCentralDirectory
+        var zipFileCommentLength = self.zipFileCommentLength
+        var data = Data(buffer: UnsafeBufferPointer(start: &endOfCentralDirectorySignature, count: 1))
+        data.append(UnsafeBufferPointer(start: &numberOfDisk, count: 1))
+        data.append(UnsafeBufferPointer(start: &numberOfDiskStart, count: 1))
+        data.append(UnsafeBufferPointer(start: &totalNumberOfEntriesOnDisk, count: 1))
+        data.append(UnsafeBufferPointer(start: &totalNumberOfEntriesInCentralDirectory, count: 1))
+        data.append(UnsafeBufferPointer(start: &sizeOfCentralDirectory, count: 1))
+        data.append(UnsafeBufferPointer(start: &offsetToStartOfCentralDirectory, count: 1))
+        data.append(UnsafeBufferPointer(start: &zipFileCommentLength, count: 1))
+        data.append(self.zipFileCommentData)
+        return data
+    }
+
+    init?(data: Data, additionalDataProvider provider: (Int) throws -> Data) {
+        guard data.count == Archive.EndOfCentralDirectoryRecord.size else { return nil }
+        guard data.scanValue(start: 0) == endOfCentralDirectorySignature else { return nil }
+        self.numberOfDisk = data.scanValue(start: 4)
+        self.numberOfDiskStart = data.scanValue(start: 6)
+        self.totalNumberOfEntriesOnDisk = data.scanValue(start: 8)
+        self.totalNumberOfEntriesInCentralDirectory = data.scanValue(start: 10)
+        self.sizeOfCentralDirectory = data.scanValue(start: 12)
+        self.offsetToStartOfCentralDirectory = data.scanValue(start: 16)
+        self.zipFileCommentLength = data.scanValue(start: 20)
+        guard let commentData = try? provider(Int(self.zipFileCommentLength)) else { return nil }
+        guard commentData.count == Int(self.zipFileCommentLength) else { return nil }
+        self.zipFileCommentData = commentData
+    }
+
+    init(record: Archive.EndOfCentralDirectoryRecord,
+         numberOfEntriesOnDisk: UInt16,
+         numberOfEntriesInCentralDirectory: UInt16,
+         updatedSizeOfCentralDirectory: UInt32,
+         startOfCentralDirectory: UInt32) {
+        numberOfDisk = record.numberOfDisk
+        numberOfDiskStart = record.numberOfDiskStart
+        totalNumberOfEntriesOnDisk = numberOfEntriesOnDisk
+        totalNumberOfEntriesInCentralDirectory = numberOfEntriesInCentralDirectory
+        sizeOfCentralDirectory = updatedSizeOfCentralDirectory
+        offsetToStartOfCentralDirectory = startOfCentralDirectory
+        zipFileCommentLength = record.zipFileCommentLength
+        zipFileCommentData = record.zipFileCommentData
+    }
+}

--- a/FlintCore/Utils/Zip/Data+Compression.swift
+++ b/FlintCore/Utils/Zip/Data+Compression.swift
@@ -1,0 +1,306 @@
+//
+//  Data+Compression.swift
+//  ZIPFoundation
+//
+//  Copyright © 2017 Thomas Zoechling, https://www.peakstep.com and the ZIP Foundation project authors.
+//  Released under the MIT License.
+//
+//  See https://github.com/weichsel/ZIPFoundation/blob/master/LICENSE for license information.
+//
+
+import Foundation
+
+/// An unsigned 32-Bit Integer representing a checksum.
+public typealias CRC32 = UInt32
+/// A custom handler that consumes a `Data` object containing partial entry data.
+/// - Parameters:
+///   - data: A chunk of `Data` to consume.
+/// - Throws: Can throw to indicate errors during data consumption.
+public typealias Consumer = (_ data: Data) throws -> Void
+/// A custom handler that receives a position and a size that can be used to provide data from an arbitrary source.
+/// - Parameters:
+///   - position: The current read position.
+///   - size: The size of the chunk to provide.
+/// - Returns: A chunk of `Data`.
+/// - Throws: Can throw to indicate errors in the data source.
+public typealias Provider = (_ position: Int, _ size: Int) throws -> Data
+
+/// The lookup table used to calculate `CRC32` checksums.
+public let crcTable: [UInt32] = [
+    0x00000000, 0x77073096, 0xee0e612c, 0x990951ba, 0x076dc419,
+    0x706af48f, 0xe963a535, 0x9e6495a3, 0x0edb8832, 0x79dcb8a4,
+    0xe0d5e91e, 0x97d2d988, 0x09b64c2b, 0x7eb17cbd, 0xe7b82d07,
+    0x90bf1d91, 0x1db71064, 0x6ab020f2, 0xf3b97148, 0x84be41de,
+    0x1adad47d, 0x6ddde4eb, 0xf4d4b551, 0x83d385c7, 0x136c9856,
+    0x646ba8c0, 0xfd62f97a, 0x8a65c9ec, 0x14015c4f, 0x63066cd9,
+    0xfa0f3d63, 0x8d080df5, 0x3b6e20c8, 0x4c69105e, 0xd56041e4,
+    0xa2677172, 0x3c03e4d1, 0x4b04d447, 0xd20d85fd, 0xa50ab56b,
+    0x35b5a8fa, 0x42b2986c, 0xdbbbc9d6, 0xacbcf940, 0x32d86ce3,
+    0x45df5c75, 0xdcd60dcf, 0xabd13d59, 0x26d930ac, 0x51de003a,
+    0xc8d75180, 0xbfd06116, 0x21b4f4b5, 0x56b3c423, 0xcfba9599,
+    0xb8bda50f, 0x2802b89e, 0x5f058808, 0xc60cd9b2, 0xb10be924,
+    0x2f6f7c87, 0x58684c11, 0xc1611dab, 0xb6662d3d, 0x76dc4190,
+    0x01db7106, 0x98d220bc, 0xefd5102a, 0x71b18589, 0x06b6b51f,
+    0x9fbfe4a5, 0xe8b8d433, 0x7807c9a2, 0x0f00f934, 0x9609a88e,
+    0xe10e9818, 0x7f6a0dbb, 0x086d3d2d, 0x91646c97, 0xe6635c01,
+    0x6b6b51f4, 0x1c6c6162, 0x856530d8, 0xf262004e, 0x6c0695ed,
+    0x1b01a57b, 0x8208f4c1, 0xf50fc457, 0x65b0d9c6, 0x12b7e950,
+    0x8bbeb8ea, 0xfcb9887c, 0x62dd1ddf, 0x15da2d49, 0x8cd37cf3,
+    0xfbd44c65, 0x4db26158, 0x3ab551ce, 0xa3bc0074, 0xd4bb30e2,
+    0x4adfa541, 0x3dd895d7, 0xa4d1c46d, 0xd3d6f4fb, 0x4369e96a,
+    0x346ed9fc, 0xad678846, 0xda60b8d0, 0x44042d73, 0x33031de5,
+    0xaa0a4c5f, 0xdd0d7cc9, 0x5005713c, 0x270241aa, 0xbe0b1010,
+    0xc90c2086, 0x5768b525, 0x206f85b3, 0xb966d409, 0xce61e49f,
+    0x5edef90e, 0x29d9c998, 0xb0d09822, 0xc7d7a8b4, 0x59b33d17,
+    0x2eb40d81, 0xb7bd5c3b, 0xc0ba6cad, 0xedb88320, 0x9abfb3b6,
+    0x03b6e20c, 0x74b1d29a, 0xead54739, 0x9dd277af, 0x04db2615,
+    0x73dc1683, 0xe3630b12, 0x94643b84, 0x0d6d6a3e, 0x7a6a5aa8,
+    0xe40ecf0b, 0x9309ff9d, 0x0a00ae27, 0x7d079eb1, 0xf00f9344,
+    0x8708a3d2, 0x1e01f268, 0x6906c2fe, 0xf762575d, 0x806567cb,
+    0x196c3671, 0x6e6b06e7, 0xfed41b76, 0x89d32be0, 0x10da7a5a,
+    0x67dd4acc, 0xf9b9df6f, 0x8ebeeff9, 0x17b7be43, 0x60b08ed5,
+    0xd6d6a3e8, 0xa1d1937e, 0x38d8c2c4, 0x4fdff252, 0xd1bb67f1,
+    0xa6bc5767, 0x3fb506dd, 0x48b2364b, 0xd80d2bda, 0xaf0a1b4c,
+    0x36034af6, 0x41047a60, 0xdf60efc3, 0xa867df55, 0x316e8eef,
+    0x4669be79, 0xcb61b38c, 0xbc66831a, 0x256fd2a0, 0x5268e236,
+    0xcc0c7795, 0xbb0b4703, 0x220216b9, 0x5505262f, 0xc5ba3bbe,
+    0xb2bd0b28, 0x2bb45a92, 0x5cb36a04, 0xc2d7ffa7, 0xb5d0cf31,
+    0x2cd99e8b, 0x5bdeae1d, 0x9b64c2b0, 0xec63f226, 0x756aa39c,
+    0x026d930a, 0x9c0906a9, 0xeb0e363f, 0x72076785, 0x05005713,
+    0x95bf4a82, 0xe2b87a14, 0x7bb12bae, 0x0cb61b38, 0x92d28e9b,
+    0xe5d5be0d, 0x7cdcefb7, 0x0bdbdf21, 0x86d3d2d4, 0xf1d4e242,
+    0x68ddb3f8, 0x1fda836e, 0x81be16cd, 0xf6b9265b, 0x6fb077e1,
+    0x18b74777, 0x88085ae6, 0xff0f6a70, 0x66063bca, 0x11010b5c,
+    0x8f659eff, 0xf862ae69, 0x616bffd3, 0x166ccf45, 0xa00ae278,
+    0xd70dd2ee, 0x4e048354, 0x3903b3c2, 0xa7672661, 0xd06016f7,
+    0x4969474d, 0x3e6e77db, 0xaed16a4a, 0xd9d65adc, 0x40df0b66,
+    0x37d83bf0, 0xa9bcae53, 0xdebb9ec5, 0x47b2cf7f, 0x30b5ffe9,
+    0xbdbdf21c, 0xcabac28a, 0x53b39330, 0x24b4a3a6, 0xbad03605,
+    0xcdd70693, 0x54de5729, 0x23d967bf, 0xb3667a2e, 0xc4614ab8,
+    0x5d681b02, 0x2a6f2b94, 0xb40bbe37, 0xc30c8ea1, 0x5a05df1b,
+    0x2d02ef8d]
+
+extension Data {
+    enum CompressionError: Error {
+        case invalidStream
+        case corruptedData
+    }
+
+    /// Calculates the `CRC32` checksum of the receiver.
+    ///
+    /// - Parameter checksum: The starting seed.
+    /// - Returns: The checksum calcualted from the bytes of the receiver and the starting seed.
+    @inline(__always)
+    public func crc32(checksum: CRC32) -> CRC32 {
+        // The typecast is necessary on 32-bit platforms because of
+        // https://bugs.swift.org/browse/SR-1774
+        let mask = 0xffffffff as UInt32
+        let bufferSize = self.count/MemoryLayout<UInt8>.size
+        var result = checksum ^ mask
+        self.withUnsafeBytes { (bytes: UnsafePointer<UInt8>) in
+            let bins = stride(from: 0, to: bufferSize, by: 256)
+            for bin in bins {
+                for binIndex in 0..<256 {
+                    let byteIndex = bin + binIndex
+                    guard byteIndex < bufferSize else { break }
+
+                    let byte = bytes[byteIndex]
+                    let index = Int((result ^ UInt32(byte)) & 0xff)
+                    result = (result >> 8) ^ crcTable[index]
+                }
+            }
+        }
+        return result ^ mask
+    }
+
+    static func compress(size: Int, bufferSize: Int, provider: Provider, consumer: Consumer) throws -> CRC32 {
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+        return try self.process(operation: COMPRESSION_STREAM_ENCODE, size: size, bufferSize: bufferSize,
+                                provider: provider, consumer: consumer)
+        #else
+        return try self.encode(size: size, bufferSize: bufferSize, provider: provider, consumer: consumer)
+        #endif
+    }
+
+    static func decompress(size: Int, bufferSize: Int, provider: Provider, consumer: Consumer) throws -> CRC32 {
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+        return try self.process(operation: COMPRESSION_STREAM_DECODE, size: size, bufferSize: bufferSize,
+                                provider: provider, consumer: consumer)
+        #else
+        return try self.decode(bufferSize: bufferSize, provider: provider, consumer: consumer)
+        #endif
+    }
+}
+
+// MARK: - Apple Platforms
+
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+import Compression
+
+extension Data {
+    @inline(__always)
+    static func process(operation: compression_stream_operation, size: Int, bufferSize: Int,
+                        provider: Provider, consumer: Consumer) throws -> CRC32 {
+        var position = 0
+        var checksum = CRC32(0)
+        let streamPtr = UnsafeMutablePointer<compression_stream>.allocate(capacity: 1)
+        defer { free(streamPtr) }
+        var stream = streamPtr.pointee
+        var status = compression_stream_init(&stream, operation, COMPRESSION_ZLIB)
+        defer { compression_stream_destroy(&stream) }
+        stream.src_size = 0
+        let bufferPtr = UnsafeMutablePointer<UInt8>.allocate(capacity: bufferSize)
+        defer { free(bufferPtr) }
+        var chunk = Data()
+        stream.dst_ptr = bufferPtr
+        stream.dst_size = bufferSize
+        var flags = Int32(0)
+        repeat {
+            let readSize = (size - position) >= bufferSize ? bufferSize : (size - position)
+            position = try self.fill(stream: &stream, checksum: &checksum, chunk: &chunk,
+                                     progress: (advance: (position: position, readSize: readSize),
+                                                configuration: (operation: operation, flags: flags)),
+                                     provider: provider)
+            try self.flush(stream: &stream, checksum: &checksum, buffer: (pointer: bufferPtr, size: bufferSize),
+                           operation: operation, consumer: consumer)
+            if position >= size { flags = Int32(COMPRESSION_STREAM_FINALIZE.rawValue) }
+            status = compression_stream_process(&stream, flags)
+            switch status {
+            case COMPRESSION_STATUS_OK:
+                try self.flush(stream: &stream, checksum: &checksum, buffer: (pointer: bufferPtr, size: bufferSize),
+                               operation: operation, consumer: consumer)
+            case COMPRESSION_STATUS_END:
+                if stream.dst_ptr > bufferPtr {
+                    let outputSize = stream.dst_ptr - bufferPtr
+                    let outputData = Data(bytesNoCopy: bufferPtr, count: outputSize, deallocator: .none)
+                    try consumer(outputData)
+                    if operation == COMPRESSION_STREAM_DECODE { checksum = outputData.crc32(checksum: checksum) }
+                }
+            case COMPRESSION_STATUS_ERROR: fallthrough
+            default: throw CompressionError.corruptedData
+            }
+        } while (status == COMPRESSION_STATUS_OK)
+        return checksum
+    }
+
+    @inline(__always)
+    static func fill(stream: inout compression_stream, checksum: inout CRC32, chunk: inout Data,
+                     progress: (advance: (position: Int, readSize: Int),
+                     configuration: (operation: compression_stream_operation, flags: Int32)),
+                     provider: Provider) throws -> Int {
+        var resultPosition = progress.advance.position
+        if stream.src_size == 0 {
+            let shouldProvideData = progress.configuration.flags != Int32(COMPRESSION_STREAM_FINALIZE.rawValue)
+            if shouldProvideData || progress.configuration.operation == COMPRESSION_STREAM_ENCODE {
+                chunk = try provider(progress.advance.position, progress.advance.readSize)
+                chunk.withUnsafeBytes { stream.src_ptr = $0 }
+                if progress.configuration.operation == COMPRESSION_STREAM_ENCODE {
+                    checksum = chunk.crc32(checksum: checksum)
+                }
+                resultPosition += chunk.count
+                stream.src_size = chunk.count
+            }
+        }
+        return resultPosition
+    }
+
+    @inline(__always)
+    static func flush(stream: inout compression_stream, checksum: inout CRC32,
+                      buffer: (size: Int, pointer: UnsafeMutablePointer<UInt8>),
+                      operation: compression_stream_operation, consumer: Consumer) throws {
+        if stream.dst_size == 0 {
+            let outputData = Data(bytesNoCopy: buffer.pointer, count: buffer.size, deallocator: .none)
+            try consumer(outputData)
+            if operation == COMPRESSION_STREAM_DECODE {
+                checksum = outputData.crc32(checksum: checksum)
+            }
+            stream.dst_ptr = buffer.pointer
+            stream.dst_size = buffer.size
+        }
+    }
+}
+
+// MARK: - Linux
+
+#else
+import CZlib
+
+extension Data {
+    @inline(__always)
+    static func encode(size: Int, bufferSize: Int, provider: Provider, consumer: Consumer) throws -> CRC32 {
+        var stream = z_stream()
+        let streamSize = Int32(MemoryLayout<z_stream>.size)
+        var result = deflateInit2_(&stream, Z_DEFAULT_COMPRESSION,
+                                   Z_DEFLATED, -MAX_WBITS, 9, Z_DEFAULT_STRATEGY, ZLIB_VERSION, streamSize)
+        defer { deflateEnd(&stream) }
+        guard result == Z_OK else { throw CompressionError.invalidStream }
+        var flush = Z_NO_FLUSH
+        var position = 0
+        var zipCRC32 = CRC32(0)
+        repeat {
+            let readSize = (size - position) >= bufferSize ? bufferSize : (size - position)
+            var inputChunk = try provider(position, readSize)
+            stream.avail_in = UInt32(inputChunk.count)
+            inputChunk.withUnsafeMutableBytes { (bytes: UnsafeMutablePointer<Bytef>) in
+                stream.next_in = bytes
+            }
+            zipCRC32 = inputChunk.crc32(checksum: zipCRC32)
+            flush = position + bufferSize >= size ? Z_FINISH : Z_NO_FLUSH
+            var outputChunk = Data(count: bufferSize)
+            repeat {
+                stream.avail_out = UInt32(bufferSize)
+                outputChunk.withUnsafeMutableBytes({ (bytes: UnsafeMutablePointer<Bytef>) in
+                    stream.next_out = bytes
+                })
+                result = deflate(&stream, flush)
+                guard result >= Z_OK  else {
+                    throw CompressionError.corruptedData
+                }
+                outputChunk.count = bufferSize - Int(stream.avail_out)
+                try consumer(outputChunk)
+            } while stream.avail_out == 0
+            position += readSize
+        } while flush != Z_FINISH
+        return zipCRC32
+    }
+
+    @inline(__always)
+    static func decode(bufferSize: Int, provider: Provider, consumer: Consumer) throws -> CRC32 {
+        var stream = z_stream()
+        let streamSize = Int32(MemoryLayout<z_stream>.size)
+        var result = inflateInit2_(&stream, -MAX_WBITS, ZLIB_VERSION, streamSize)
+        defer { inflateEnd(&stream) }
+        guard result == Z_OK else { throw CompressionError.invalidStream }
+        var unzipCRC32 = CRC32(0)
+        var position = 0
+        repeat {
+            let inputBytes = malloc(bufferSize)
+            defer { free(inputBytes) }
+            stream.avail_in = UInt32(bufferSize)
+            var chunk = try provider(position, bufferSize)
+            position += chunk.count
+            chunk.withUnsafeMutableBytes { (bytes: UnsafeMutablePointer<Bytef>) in
+                stream.next_in = bytes
+            }
+            repeat {
+                var outputData = Data(count: bufferSize)
+                stream.avail_out = UInt32(bufferSize)
+                outputData.withUnsafeMutableBytes { (bytes: UnsafeMutablePointer<Bytef>) in
+                    stream.next_out = bytes
+                }
+                result = inflate(&stream, Z_NO_FLUSH)
+                guard result != Z_NEED_DICT &&
+                    result != Z_DATA_ERROR &&
+                    result != Z_MEM_ERROR else {
+                        throw CompressionError.corruptedData
+                }
+                let remainingLength = UInt32(bufferSize) - stream.avail_out
+                outputData.count = Int(remainingLength)
+                try consumer(outputData)
+                unzipCRC32 = outputData.crc32(checksum: unzipCRC32)
+            } while stream.avail_out == 0
+        } while result != Z_STREAM_END
+        return unzipCRC32
+    }
+}
+#endif

--- a/FlintCore/Utils/Zip/Data+Serialization.swift
+++ b/FlintCore/Utils/Zip/Data+Serialization.swift
@@ -1,0 +1,82 @@
+//
+//  Data+Serialization.swift
+//  ZIPFoundation
+//
+//  Copyright © 2017 Thomas Zoechling, https://www.peakstep.com and the ZIP Foundation project authors.
+//  Released under the MIT License.
+//
+//  See https://github.com/weichsel/ZIPFoundation/blob/master/LICENSE for license information.
+//
+
+import Foundation
+
+protocol DataSerializable {
+    static var size: Int { get }
+    init?(data: Data, additionalDataProvider: (Int) throws -> Data)
+    var data: Data { get }
+}
+
+extension Data {
+    enum DataError: Error {
+        case unreadableFile
+        case unwritableFile
+    }
+
+    func scanValue<T>(start: Int) -> T {
+        return self.subdata(in: start..<start+MemoryLayout<T>.size).withUnsafeBytes { $0.pointee }
+    }
+
+    static func readStruct<T>(from file: UnsafeMutablePointer<FILE>, at offset: Int) -> T? where T: DataSerializable {
+        fseek(file, offset, SEEK_SET)
+        guard let data = try? self.readChunk(of: T.size, from: file) else {
+            return nil
+        }
+        let structure = T(data: data, additionalDataProvider: { (additionalDataSize) -> Data in
+            return try self.readChunk(of: additionalDataSize, from: file)
+        })
+        return structure
+    }
+
+    static func consumePart(of size: Int, chunkSize: Int, skipCRC32: Bool = false,
+                            provider: Provider, consumer: Consumer) throws -> CRC32 {
+        let readInOneChunk = (size < chunkSize)
+        var chunkSize = readInOneChunk ? size : chunkSize
+        var checksum = CRC32(0)
+        var bytesRead = 0
+        while bytesRead < size {
+            let remainingSize = size - bytesRead
+            chunkSize = remainingSize < chunkSize ? remainingSize : chunkSize
+            let data = try provider(bytesRead, chunkSize)
+            try consumer(data)
+            if !skipCRC32 {
+                checksum = data.crc32(checksum: checksum)
+            }
+            bytesRead += chunkSize
+        }
+        return checksum
+    }
+
+    static func readChunk(of size: Int, from file: UnsafeMutablePointer<FILE>) throws -> Data {
+        #if swift(>=4.1)
+        let bytes = UnsafeMutableRawPointer.allocate(byteCount: size, alignment: 1)
+        #else
+        let bytes = UnsafeMutableRawPointer.allocate(bytes: size, alignedTo: 1)
+        #endif
+        let bytesRead = fread(bytes, 1, size, file)
+        let error = ferror(file)
+        if error > 0 {
+            throw DataError.unreadableFile
+        }
+        return Data(bytesNoCopy: bytes, count: bytesRead, deallocator: Data.Deallocator.free)
+    }
+
+    static func write(chunk: Data, to file: UnsafeMutablePointer<FILE>) throws -> Int {
+        var sizeWritten = 0
+        chunk.withUnsafeBytes { sizeWritten = fwrite($0, 1, chunk.count, file) }
+        let error = ferror(file)
+        if error > 0 {
+            throw DataError.unwritableFile
+        }
+        return sizeWritten
+    }
+}

--- a/FlintCore/Utils/Zip/Entry.swift
+++ b/FlintCore/Utils/Zip/Entry.swift
@@ -1,0 +1,400 @@
+//
+//  Entry.swift
+//  ZIPFoundation
+//
+//  Copyright © 2017 Thomas Zoechling, https://www.peakstep.com and the ZIP Foundation project authors.
+//  Released under the MIT License.
+//
+//  See https://github.com/weichsel/ZIPFoundation/blob/master/LICENSE for license information.
+//
+
+import Foundation
+import CoreFoundation
+
+/// A value that represents a file, a direcotry or a symbolic link within a ZIP `Archive`.
+///
+/// You can retrieve instances of `Entry` from an `Archive` via subscripting or iteration.
+/// Entries are identified by their `path`.
+public struct Entry: Equatable {
+    /// The type of an `Entry` in a ZIP `Archive`.
+    public enum EntryType: Int {
+        /// Indicates a regular file.
+        case file
+        /// Indicates a directory.
+        case directory
+        /// Indicates a symbolic link.
+        case symlink
+
+        init(mode: mode_t) {
+            switch mode & S_IFMT {
+            case S_IFDIR:
+                self = .directory
+            case S_IFLNK:
+                self = .symlink
+            default:
+                self = .file
+            }
+        }
+    }
+
+    enum OSType: UInt {
+        case msdos = 0
+        case unix = 3
+        case osx = 19
+        case unused = 20
+    }
+
+    struct LocalFileHeader: DataSerializable {
+        let localFileHeaderSignature = UInt32(localFileHeaderStructSignature)
+        let versionNeededToExtract: UInt16
+        let generalPurposeBitFlag: UInt16
+        let compressionMethod: UInt16
+        let lastModFileTime: UInt16
+        let lastModFileDate: UInt16
+        let crc32: UInt32
+        let compressedSize: UInt32
+        let uncompressedSize: UInt32
+        let fileNameLength: UInt16
+        let extraFieldLength: UInt16
+        static let size = 30
+        let fileNameData: Data
+        let extraFieldData: Data
+    }
+
+    struct DataDescriptor: DataSerializable {
+        let data: Data
+        let dataDescriptorSignature = UInt32(dataDescriptorStructSignature)
+        let crc32: UInt32
+        let compressedSize: UInt32
+        let uncompressedSize: UInt32
+        static let size = 16
+    }
+
+    struct CentralDirectoryStructure: DataSerializable {
+        let centralDirectorySignature = UInt32(centralDirectoryStructSignature)
+        let versionMadeBy: UInt16
+        let versionNeededToExtract: UInt16
+        let generalPurposeBitFlag: UInt16
+        let compressionMethod: UInt16
+        let lastModFileTime: UInt16
+        let lastModFileDate: UInt16
+        let crc32: UInt32
+        let compressedSize: UInt32
+        let uncompressedSize: UInt32
+        let fileNameLength: UInt16
+        let extraFieldLength: UInt16
+        let fileCommentLength: UInt16
+        let diskNumberStart: UInt16
+        let internalFileAttributes: UInt16
+        let externalFileAttributes: UInt32
+        let relativeOffsetOfLocalHeader: UInt32
+        static let size = 46
+        let fileNameData: Data
+        let extraFieldData: Data
+        let fileCommentData: Data
+        var usesDataDescriptor: Bool { return (self.generalPurposeBitFlag & (1 << 3 )) != 0 }
+        var isZIP64: Bool { return self.versionNeededToExtract >= 45 }
+        var isEncrypted: Bool { return (self.generalPurposeBitFlag & (1 << 0)) != 0 }
+    }
+
+    /// The `path` of the receiver within a ZIP `Archive`.
+    public var path: String {
+        let dosLatinUS = 0x400
+        let dosLatinUSEncoding = CFStringEncoding(dosLatinUS)
+        let dosLatinUSStringEncoding = CFStringConvertEncodingToNSStringEncoding(dosLatinUSEncoding)
+        let codepage437 = String.Encoding(rawValue: dosLatinUSStringEncoding)
+        let isUTF8 = ((self.centralDirectoryStructure.generalPurposeBitFlag >> 11) & 1) != 0
+        let encoding = isUTF8 ? String.Encoding.utf8 : codepage437
+        return String(data: self.centralDirectoryStructure.fileNameData, encoding: encoding) ?? ""
+    }
+    /// The file attributes of the receiver as key/value pairs.
+    ///
+    /// Contains the modification date and file permissions.
+    public var fileAttributes: [FileAttributeKey: Any] {
+        return FileManager.attributes(from: self)
+    }
+    /// The `CRC32` checksum of the receiver.
+    ///
+    /// - Note: Always returns `0` for entries of type `EntryType.directory`.
+    public var checksum: CRC32 {
+        var checksum = self.centralDirectoryStructure.crc32
+        if self.centralDirectoryStructure.usesDataDescriptor {
+            guard let dataDescriptor = self.dataDescriptor else {
+                return 0
+            }
+            checksum = dataDescriptor.crc32
+        }
+        return checksum
+    }
+    /// The `EntryType` of the receiver.
+    public var type: EntryType {
+        // OS Type is stored in the upper byte of versionMadeBy
+        let osTypeRaw = self.centralDirectoryStructure.versionMadeBy >> 8
+        let osType = OSType(rawValue: UInt(osTypeRaw)) ?? .unused
+        var isDirectory = self.path.hasSuffix("/")
+        switch osType {
+        case .unix, .osx:
+            let mode = mode_t(self.centralDirectoryStructure.externalFileAttributes >> 16) & S_IFMT
+            switch mode {
+            case S_IFREG:
+                return .file
+            case S_IFDIR:
+                return .directory
+            case S_IFLNK:
+                return .symlink
+            default:
+                return .file
+            }
+        case .msdos:
+            isDirectory = isDirectory || ((centralDirectoryStructure.externalFileAttributes >> 4) == 0x01)
+            fallthrough
+        default:
+            // for all other OSes we can only guess based on the directory suffix char
+            return isDirectory ? .directory : .file
+        }
+    }
+    /// The size of the receiver's compressed data.
+    public var compressedSize: Int {
+        return Int(dataDescriptor?.compressedSize ?? localFileHeader.compressedSize)
+    }
+    /// The size of the receiver's uncompressed data.
+    public var uncompressedSize: Int {
+        return Int(dataDescriptor?.uncompressedSize ?? localFileHeader.uncompressedSize)
+    }
+    /// The combined size of the local header, the data and the optional data descriptor.
+    var localSize: Int {
+        let localFileHeader = self.localFileHeader
+        var extraDataLength = Int(localFileHeader.fileNameLength)
+        extraDataLength += Int(localFileHeader.extraFieldLength)
+        var size = LocalFileHeader.size + extraDataLength
+        let isCompressed = localFileHeader.compressionMethod != CompressionMethod.none.rawValue
+        size += isCompressed ? self.compressedSize : self.uncompressedSize
+        size += self.dataDescriptor != nil ? DataDescriptor.size : 0
+        return size
+    }
+    var dataOffset: Int {
+        var dataOffset = Int(self.centralDirectoryStructure.relativeOffsetOfLocalHeader)
+        dataOffset += LocalFileHeader.size
+        dataOffset += Int(self.localFileHeader.fileNameLength)
+        dataOffset += Int(self.localFileHeader.extraFieldLength)
+        return dataOffset
+    }
+    let centralDirectoryStructure: CentralDirectoryStructure
+    let localFileHeader: LocalFileHeader
+    let dataDescriptor: DataDescriptor?
+
+    public static func == (lhs: Entry, rhs: Entry) -> Bool {
+        return lhs.path == rhs.path
+            && lhs.localFileHeader.crc32
+            == rhs.localFileHeader.crc32
+            && lhs.centralDirectoryStructure.relativeOffsetOfLocalHeader
+            == rhs.centralDirectoryStructure.relativeOffsetOfLocalHeader
+    }
+
+    init?(centralDirectoryStructure: CentralDirectoryStructure,
+          localFileHeader: LocalFileHeader,
+          dataDescriptor: DataDescriptor?) {
+        // We currently don't support ZIP64 or encrypted archives
+        guard !centralDirectoryStructure.isZIP64 else { return nil }
+        guard !centralDirectoryStructure.isEncrypted else { return nil }
+        self.centralDirectoryStructure = centralDirectoryStructure
+        self.localFileHeader = localFileHeader
+        self.dataDescriptor = dataDescriptor
+    }
+}
+
+extension Entry.LocalFileHeader {
+    var data: Data {
+        var localFileHeaderSignature = self.localFileHeaderSignature
+        var versionNeededToExtract = self.versionNeededToExtract
+        var generalPurposeBitFlag = self.generalPurposeBitFlag
+        var compressionMethod = self.compressionMethod
+        var lastModFileTime = self.lastModFileTime
+        var lastModFileDate = self.lastModFileDate
+        var crc32 = self.crc32
+        var compressedSize = self.compressedSize
+        var uncompressedSize = self.uncompressedSize
+        var fileNameLength = self.fileNameLength
+        var extraFieldLength = self.extraFieldLength
+        var data = Data(buffer: UnsafeBufferPointer(start: &localFileHeaderSignature, count: 1))
+        data.append(UnsafeBufferPointer(start: &versionNeededToExtract, count: 1))
+        data.append(UnsafeBufferPointer(start: &generalPurposeBitFlag, count: 1))
+        data.append(UnsafeBufferPointer(start: &compressionMethod, count: 1))
+        data.append(UnsafeBufferPointer(start: &lastModFileTime, count: 1))
+        data.append(UnsafeBufferPointer(start: &lastModFileDate, count: 1))
+        data.append(UnsafeBufferPointer(start: &crc32, count: 1))
+        data.append(UnsafeBufferPointer(start: &compressedSize, count: 1))
+        data.append(UnsafeBufferPointer(start: &uncompressedSize, count: 1))
+        data.append(UnsafeBufferPointer(start: &fileNameLength, count: 1))
+        data.append(UnsafeBufferPointer(start: &extraFieldLength, count: 1))
+        data.append(self.fileNameData)
+        data.append(self.extraFieldData)
+        return data
+    }
+
+    init?(data: Data, additionalDataProvider provider: (Int) throws -> Data) {
+        guard data.count == Entry.LocalFileHeader.size else { return nil }
+        guard data.scanValue(start: 0) == localFileHeaderSignature else { return nil }
+        self.versionNeededToExtract = data.scanValue(start: 4)
+        self.generalPurposeBitFlag = data.scanValue(start: 6)
+        self.compressionMethod = data.scanValue(start: 8)
+        self.lastModFileTime = data.scanValue(start: 10)
+        self.lastModFileDate = data.scanValue(start: 12)
+        self.crc32 = data.scanValue(start: 14)
+        self.compressedSize = data.scanValue(start: 18)
+        self.uncompressedSize = data.scanValue(start: 22)
+        self.fileNameLength = data.scanValue(start: 26)
+        self.extraFieldLength = data.scanValue(start: 28)
+        let additionalDataLength = Int(self.fileNameLength + self.extraFieldLength)
+        guard let additionalData = try? provider(additionalDataLength) else { return nil }
+        guard additionalData.count == additionalDataLength else { return nil }
+        var subRangeStart = 0
+        var subRangeEnd = Int(self.fileNameLength)
+        self.fileNameData = additionalData.subdata(in: subRangeStart..<subRangeEnd)
+        subRangeStart += Int(self.fileNameLength)
+        subRangeEnd = subRangeStart + Int(self.extraFieldLength)
+        self.extraFieldData = additionalData.subdata(in: subRangeStart..<subRangeEnd)
+    }
+}
+
+extension Entry.CentralDirectoryStructure {
+    var data: Data {
+        var centralDirectorySignature = self.centralDirectorySignature
+        var versionMadeBy = self.versionMadeBy
+        var versionNeededToExtract = self.versionNeededToExtract
+        var generalPurposeBitFlag = self.generalPurposeBitFlag
+        var compressionMethod = self.compressionMethod
+        var lastModFileTime = self.lastModFileTime
+        var lastModFileDate = self.lastModFileDate
+        var crc32 = self.crc32
+        var compressedSize = self.compressedSize
+        var uncompressedSize = self.uncompressedSize
+        var fileNameLength = self.fileNameLength
+        var extraFieldLength = self.extraFieldLength
+        var fileCommentLength = self.fileCommentLength
+        var diskNumberStart = self.diskNumberStart
+        var internalFileAttributes = self.internalFileAttributes
+        var externalFileAttributes = self.externalFileAttributes
+        var relativeOffsetOfLocalHeader = self.relativeOffsetOfLocalHeader
+        var data = Data(buffer: UnsafeBufferPointer(start: &centralDirectorySignature, count: 1))
+        data.append(UnsafeBufferPointer(start: &versionMadeBy, count: 1))
+        data.append(UnsafeBufferPointer(start: &versionNeededToExtract, count: 1))
+        data.append(UnsafeBufferPointer(start: &generalPurposeBitFlag, count: 1))
+        data.append(UnsafeBufferPointer(start: &compressionMethod, count: 1))
+        data.append(UnsafeBufferPointer(start: &lastModFileTime, count: 1))
+        data.append(UnsafeBufferPointer(start: &lastModFileDate, count: 1))
+        data.append(UnsafeBufferPointer(start: &crc32, count: 1))
+        data.append(UnsafeBufferPointer(start: &compressedSize, count: 1))
+        data.append(UnsafeBufferPointer(start: &uncompressedSize, count: 1))
+        data.append(UnsafeBufferPointer(start: &fileNameLength, count: 1))
+        data.append(UnsafeBufferPointer(start: &extraFieldLength, count: 1))
+        data.append(UnsafeBufferPointer(start: &fileCommentLength, count: 1))
+        data.append(UnsafeBufferPointer(start: &diskNumberStart, count: 1))
+        data.append(UnsafeBufferPointer(start: &internalFileAttributes, count: 1))
+        data.append(UnsafeBufferPointer(start: &externalFileAttributes, count: 1))
+        data.append(UnsafeBufferPointer(start: &relativeOffsetOfLocalHeader, count: 1))
+        data.append(self.fileNameData)
+        data.append(self.extraFieldData)
+        data.append(self.fileCommentData)
+        return data
+    }
+
+    init?(data: Data, additionalDataProvider provider: (Int) throws -> Data) {
+        guard data.count == Entry.CentralDirectoryStructure.size else { return nil }
+        guard data.scanValue(start: 0) == centralDirectorySignature else { return nil }
+        self.versionMadeBy = data.scanValue(start: 4)
+        self.versionNeededToExtract = data.scanValue(start: 6)
+        self.generalPurposeBitFlag = data.scanValue(start: 8)
+        self.compressionMethod = data.scanValue(start: 10)
+        self.lastModFileTime = data.scanValue(start: 12)
+        self.lastModFileDate = data.scanValue(start: 14)
+        self.crc32 = data.scanValue(start: 16)
+        self.compressedSize = data.scanValue(start: 20)
+        self.uncompressedSize = data.scanValue(start: 24)
+        self.fileNameLength = data.scanValue(start: 28)
+        self.extraFieldLength = data.scanValue(start: 30)
+        self.fileCommentLength = data.scanValue(start: 32)
+        self.diskNumberStart = data.scanValue(start: 34)
+        self.internalFileAttributes = data.scanValue(start: 36)
+        self.externalFileAttributes = data.scanValue(start: 38)
+        self.relativeOffsetOfLocalHeader = data.scanValue(start: 42)
+        let additionalDataLength = Int(self.fileNameLength + self.extraFieldLength + self.fileCommentLength)
+        guard let additionalData = try? provider(additionalDataLength) else { return nil }
+        guard additionalData.count == additionalDataLength else { return nil }
+        var subRangeStart = 0
+        var subRangeEnd = Int(self.fileNameLength)
+        self.fileNameData = additionalData.subdata(in: subRangeStart..<subRangeEnd)
+        subRangeStart += Int(self.fileNameLength)
+        subRangeEnd = subRangeStart + Int(self.extraFieldLength)
+        self.extraFieldData = additionalData.subdata(in: subRangeStart..<subRangeEnd)
+        subRangeStart += Int(self.extraFieldLength)
+        subRangeEnd = subRangeStart + Int(self.fileCommentLength)
+        self.fileCommentData = additionalData.subdata(in: subRangeStart..<subRangeEnd)
+    }
+
+    init(localFileHeader: Entry.LocalFileHeader, fileAttributes: UInt32, relativeOffset: UInt32) {
+        versionMadeBy = UInt16(789)
+        versionNeededToExtract = localFileHeader.versionNeededToExtract
+        generalPurposeBitFlag = localFileHeader.generalPurposeBitFlag
+        compressionMethod = localFileHeader.compressionMethod
+        lastModFileTime = localFileHeader.lastModFileTime
+        lastModFileDate = localFileHeader.lastModFileDate
+        crc32 = localFileHeader.crc32
+        compressedSize = localFileHeader.compressedSize
+        uncompressedSize = localFileHeader.uncompressedSize
+        fileNameLength = localFileHeader.fileNameLength
+        extraFieldLength = UInt16(0)
+        fileCommentLength = UInt16(0)
+        diskNumberStart = UInt16(0)
+        internalFileAttributes = UInt16(0)
+        externalFileAttributes = fileAttributes
+        relativeOffsetOfLocalHeader = relativeOffset
+        fileNameData = localFileHeader.fileNameData
+        extraFieldData = Data()
+        fileCommentData = Data()
+    }
+
+    init(centralDirectoryStructure: Entry.CentralDirectoryStructure, offset: UInt32) {
+        let relativeOffset = centralDirectoryStructure.relativeOffsetOfLocalHeader - offset
+        relativeOffsetOfLocalHeader = relativeOffset
+        versionMadeBy = centralDirectoryStructure.versionMadeBy
+        versionNeededToExtract = centralDirectoryStructure.versionNeededToExtract
+        generalPurposeBitFlag = centralDirectoryStructure.generalPurposeBitFlag
+        compressionMethod = centralDirectoryStructure.compressionMethod
+        lastModFileTime = centralDirectoryStructure.lastModFileTime
+        lastModFileDate = centralDirectoryStructure.lastModFileDate
+        crc32 = centralDirectoryStructure.crc32
+        compressedSize = centralDirectoryStructure.compressedSize
+        uncompressedSize = centralDirectoryStructure.uncompressedSize
+        fileNameLength = centralDirectoryStructure.fileNameLength
+        extraFieldLength = centralDirectoryStructure.extraFieldLength
+        fileCommentLength = centralDirectoryStructure.fileCommentLength
+        diskNumberStart = centralDirectoryStructure.diskNumberStart
+        internalFileAttributes = centralDirectoryStructure.internalFileAttributes
+        externalFileAttributes = centralDirectoryStructure.externalFileAttributes
+        fileNameData = centralDirectoryStructure.fileNameData
+        extraFieldData = centralDirectoryStructure.extraFieldData
+        fileCommentData = centralDirectoryStructure.fileCommentData
+    }
+}
+
+extension Entry.DataDescriptor {
+    init?(data: Data, additionalDataProvider provider: (Int) throws -> Data) {
+        guard data.count == Entry.DataDescriptor.size else { return nil }
+        let signature: UInt32 = data.scanValue(start: 0)
+        // The DataDescriptor signature is not mandatory so we have to re-arrange
+        // the input data if it is missing
+        var readOffset = 0
+        if signature == self.dataDescriptorSignature {
+            readOffset = 4
+        }
+        self.crc32 = data.scanValue(start: readOffset + 0)
+        self.compressedSize = data.scanValue(start: readOffset + 4)
+        self.uncompressedSize = data.scanValue(start: readOffset + 8)
+        // Our add(_ entry:) methods always maintain compressed & uncompressed
+        // sizes and so we don't need a data descriptor for newly added entries.
+        // Data descriptors of already existing entries are manually preserved
+        // when copying those entries to the tempArchive during remove(_ entry:).
+        self.data = Data()
+    }
+}

--- a/FlintCore/Utils/Zip/FileManager+ZIP.swift
+++ b/FlintCore/Utils/Zip/FileManager+ZIP.swift
@@ -1,0 +1,249 @@
+//
+//  FileManager+ZIP.swift
+//  ZIPFoundation
+//
+//  Copyright © 2017 Thomas Zoechling, https://www.peakstep.com and the ZIP Foundation project authors.
+//  Released under the MIT License.
+//
+//  See https://github.com/weichsel/ZIPFoundation/blob/master/LICENSE for license information.
+//
+
+import Foundation
+
+extension FileManager {
+    typealias CentralDirectoryStructure = Entry.CentralDirectoryStructure
+
+    /// Zips the file or direcory contents at the specified source URL to the destination URL.
+    ///
+    /// If the item at the source URL is a directory, the directory itself will be
+    /// represented within the ZIP `Archive`. Calling this method with a directory URL
+    /// `file:///path/directory/` will create an archive with a `directory/` entry at the root level.
+    /// You can override this behavior by passing `false` for `shouldKeepParent`. In that case, the contents
+    /// of the source directory will be placed at the root of the archive.
+    /// - Parameters:
+    ///   - sourceURL: The file URL pointing to an existing file or directory.
+    ///   - destinationURL: The file URL that identifies the destination of the zip operation.
+    ///   - shouldKeepParent: Indicates that the directory name of a source item should be used as root element
+    ///                       within the archive. Default is `true`.
+    ///   - compressionMethod: Indicates the `CompressionMethod` that should be applied.
+    ///   - progress: A progress object that can be used to track or cancel the zip operation.
+    /// - Throws: Throws an error if the source item does not exist or the destination URL is not writable.
+    public func zipItem(at sourceURL: URL, to destinationURL: URL,
+                        shouldKeepParent: Bool = true, compressionMethod: CompressionMethod = .none,
+                        progress: Progress? = nil) throws {
+        guard self.fileExists(atPath: sourceURL.path) else {
+            throw CocoaError.error(.fileReadNoSuchFile, userInfo: [NSFilePathErrorKey: sourceURL.path], url: nil)
+        }
+        guard !self.fileExists(atPath: destinationURL.path) else {
+            throw CocoaError.error(.fileWriteFileExists, userInfo: [NSFilePathErrorKey: destinationURL.path], url: nil)
+        }
+        guard let archive = Archive(url: destinationURL, accessMode: .create) else {
+            throw Archive.ArchiveError.unwritableArchive
+        }
+        let isDirectory = try FileManager.typeForItem(at: sourceURL) == .directory
+        if isDirectory {
+            let subPaths = try self.subpathsOfDirectory(atPath: sourceURL.path)
+            var totalUnitCount = Int64(0)
+            if let progress = progress {
+                totalUnitCount = subPaths.reduce(Int64(0), {
+                    let itemURL = sourceURL.appendingPathComponent($1)
+                    let itemSize = archive.totalUnitCountForAddingItem(at: itemURL)
+                    return $0 + itemSize
+                })
+                progress.totalUnitCount = totalUnitCount
+            }
+
+            // If the caller wants to keep the parent directory, we use the lastPathComponent of the source URL
+            // as common base for all entries (similar to macOS' Archive Utility.app)
+            let directoryPrefix = sourceURL.lastPathComponent
+            for entryPath in subPaths {
+                let finalEntryPath = shouldKeepParent ? directoryPrefix + "/" + entryPath : entryPath
+                let finalBaseURL = shouldKeepParent ? sourceURL.deletingLastPathComponent() : sourceURL
+                if let progress = progress {
+                    let itemURL = sourceURL.appendingPathComponent(entryPath)
+                    let entryProgress = archive.makeProgressForAddingItem(at: itemURL)
+                    progress.addChild(entryProgress, withPendingUnitCount: entryProgress.totalUnitCount)
+                    try archive.addEntry(with: finalEntryPath, relativeTo: finalBaseURL,
+                                         compressionMethod: compressionMethod, progress: entryProgress)
+                } else {
+                    try archive.addEntry(with: finalEntryPath, relativeTo: finalBaseURL,
+                                         compressionMethod: compressionMethod)
+                }
+            }
+        } else {
+            progress?.totalUnitCount = archive.totalUnitCountForAddingItem(at: sourceURL)
+            let baseURL = sourceURL.deletingLastPathComponent()
+            try archive.addEntry(with: sourceURL.lastPathComponent, relativeTo: baseURL,
+                                 compressionMethod: compressionMethod, progress: progress)
+        }
+    }
+
+    // MARK: - Helpers
+
+    class func attributes(from entry: Entry) -> [FileAttributeKey: Any] {
+        let centralDirectoryStructure = entry.centralDirectoryStructure
+        let entryType = entry.type
+        var attributes = [.posixPermissions: entryType ==
+            .directory ? defaultDirectoryPermissions : defaultFilePermissions,
+                          .modificationDate: Date()] as [FileAttributeKey: Any]
+        let versionMadeBy = centralDirectoryStructure.versionMadeBy
+        let fileTime = centralDirectoryStructure.lastModFileTime
+        let fileDate = centralDirectoryStructure.lastModFileDate
+        guard let osType = Entry.OSType(rawValue: UInt(versionMadeBy >> 8)) else {
+            return attributes
+        }
+        let externalFileAttributes = centralDirectoryStructure.externalFileAttributes
+        let permissions = self.permissions(for: externalFileAttributes, osType: osType, entryType: entryType)
+        attributes[.posixPermissions] = NSNumber(value: permissions)
+        attributes[.modificationDate] = Date(dateTime: (fileDate, fileTime))
+        return attributes
+    }
+
+    class func permissions(for externalFileAttributes: UInt32, osType: Entry.OSType,
+                           entryType: Entry.EntryType) -> UInt16 {
+        switch osType {
+        case .unix, .osx:
+            let permissions = mode_t(externalFileAttributes >> 16) & (~S_IFMT)
+            let defaultPermissions = entryType == .directory ? defaultDirectoryPermissions : defaultFilePermissions
+            return permissions == 0 ? defaultPermissions : UInt16(permissions)
+        default:
+            return entryType == .directory ? defaultDirectoryPermissions : defaultFilePermissions
+        }
+    }
+
+    class func externalFileAttributesForEntry(of type: Entry.EntryType, permissions: UInt16) -> UInt32 {
+        var typeInt: UInt16
+        switch type {
+        case .file:
+            typeInt = UInt16(S_IFREG)
+        case .directory:
+            typeInt = UInt16(S_IFDIR)
+        case .symlink:
+            typeInt = UInt16(S_IFLNK)
+        }
+        var externalFileAttributes = UInt32(typeInt|UInt16(permissions))
+        externalFileAttributes = (externalFileAttributes << 16)
+        return externalFileAttributes
+    }
+
+    class func permissionsForItem(at URL: URL) throws -> UInt16 {
+        let fileManager = FileManager()
+        let entryFileSystemRepresentation = fileManager.fileSystemRepresentation(withPath: URL.path)
+        var fileStat = stat()
+        lstat(entryFileSystemRepresentation, &fileStat)
+        let permissions = fileStat.st_mode
+        return UInt16(permissions)
+    }
+
+    class func fileModificationDateTimeForItem(at url: URL) throws -> Date {
+        let fileManager = FileManager()
+        guard fileManager.fileExists(atPath: url.path) else {
+            throw CocoaError.error(.fileReadNoSuchFile, userInfo: [NSFilePathErrorKey: url.path], url: nil)
+        }
+        let entryFileSystemRepresentation = fileManager.fileSystemRepresentation(withPath: url.path)
+        var fileStat = stat()
+        lstat(entryFileSystemRepresentation, &fileStat)
+        #if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+        let modTimeSpec = fileStat.st_mtimespec
+        #else
+        let modTimeSpec = fileStat.st_mtim
+        #endif
+
+        let timeStamp = TimeInterval(modTimeSpec.tv_sec) + TimeInterval(modTimeSpec.tv_nsec)/1000000000.0
+        let modDate = Date(timeIntervalSince1970: timeStamp)
+        return modDate
+    }
+
+    class func fileSizeForItem(at url: URL) throws -> UInt32 {
+        let fileManager = FileManager()
+        guard fileManager.fileExists(atPath: url.path) else {
+            throw CocoaError.error(.fileReadNoSuchFile, userInfo: [NSFilePathErrorKey: url.path], url: nil)
+        }
+        let entryFileSystemRepresentation = fileManager.fileSystemRepresentation(withPath: url.path)
+        var fileStat = stat()
+        lstat(entryFileSystemRepresentation, &fileStat)
+        return UInt32(fileStat.st_size)
+    }
+
+    class func typeForItem(at url: URL) throws -> Entry.EntryType {
+        let fileManager = FileManager()
+        guard fileManager.fileExists(atPath: url.path) else {
+            throw CocoaError.error(.fileReadNoSuchFile, userInfo: [NSFilePathErrorKey: url.path], url: nil)
+        }
+        let entryFileSystemRepresentation = fileManager.fileSystemRepresentation(withPath: url.path)
+        var fileStat = stat()
+        lstat(entryFileSystemRepresentation, &fileStat)
+        return Entry.EntryType(mode: fileStat.st_mode)
+    }
+}
+
+extension Date {
+    init(dateTime: (UInt16, UInt16)) {
+        var msdosDateTime = Int(dateTime.0)
+        msdosDateTime <<= 16
+        msdosDateTime |= Int(dateTime.1)
+        var unixTime = tm()
+        unixTime.tm_sec = Int32((msdosDateTime&31)*2)
+        unixTime.tm_min = Int32((msdosDateTime>>5)&63)
+        unixTime.tm_hour = Int32((Int(dateTime.1)>>11)&31)
+        unixTime.tm_mday = Int32((msdosDateTime>>16)&31)
+        unixTime.tm_mon = Int32((msdosDateTime>>21)&15)
+        unixTime.tm_mon -= 1 // UNIX time struct month entries are zero based.
+        unixTime.tm_year = Int32(1980+(msdosDateTime>>25))
+        unixTime.tm_year -= 1900 // UNIX time structs count in "years since 1900".
+        let time = timegm(&unixTime)
+        self = Date(timeIntervalSince1970: TimeInterval(time))
+    }
+
+    var fileModificationDateTime: (UInt16, UInt16) {
+        return (self.fileModificationDate, self.fileModificationTime)
+    }
+
+    var fileModificationDate: UInt16 {
+        var time = time_t(self.timeIntervalSince1970)
+        guard let unixTime = gmtime(&time) else {
+            return 0
+        }
+        var year = unixTime.pointee.tm_year + 1900 // UNIX time structs count in "years since 1900".
+        // ZIP uses the MSDOS date format which has a valid range of 1980 - 2099.
+        year = year >= 1980 ? year : 1980
+        year = year <= 2099 ? year : 2099
+        let month = unixTime.pointee.tm_mon + 1 // UNIX time struct month entries are zero based.
+        let day = unixTime.pointee.tm_mday
+        return (UInt16)(day + ((month) * 32) +  ((year - 1980) * 512))
+    }
+
+    var fileModificationTime: UInt16 {
+        var time = time_t(self.timeIntervalSince1970)
+        guard let unixTime = gmtime(&time) else {
+            return 0
+        }
+        let hour = unixTime.pointee.tm_hour
+        let minute = unixTime.pointee.tm_min
+        let second = unixTime.pointee.tm_sec
+        return (UInt16)((second/2) + (minute * 32) + (hour * 2048))
+    }
+}
+
+#if swift(>=4.2)
+#else
+
+#if os(macOS) || os(iOS) || os(watchOS) || os(tvOS)
+#else
+
+// The swift-corelibs-foundation version of NSError.swift was missing a convenience method to create
+// error objects from error codes. (https://github.com/apple/swift-corelibs-foundation/pull/1420)
+// We have to provide an implementation for non-Darwin platforms using Swift versions < 4.2.
+
+public extension CocoaError {
+    public static func error(_ code: CocoaError.Code, userInfo: [AnyHashable: Any]? = nil, url: URL? = nil) -> Error {
+        var info: [String: Any] = userInfo as? [String: Any] ?? [:]
+        if let url = url {
+            info[NSURLErrorKey] = url
+        }
+        return NSError(domain: NSCocoaErrorDomain, code: code.rawValue, userInfo: info)
+    }
+}
+
+#endif
+#endif


### PR DESCRIPTION
The extension-safe API stuff is not set on the original repo, and this removes the need to use carthage at all for Flint itself.

Later we should roll our own / do just what we need with the Apple-provided zip libs but for now this is a quick fix and has the bonus of working on Swift with linux but it's not clear that is a goal.