### PR TITLE
Remove storage of feature + action types in properties in bindings

### DIFF
--- a/FlintCore/Actions/ActionRequest.swift
+++ b/FlintCore/Actions/ActionRequest.swift
@@ -60,9 +60,9 @@ public class ActionRequest<FeatureType: FeatureDefinition, ActionType: Action>: 
     
     public var debugDescription: String {
         if userInitiated {
-            return "Request \(uniqueID) for user-initiated \(actionBinding.feature) action \(actionBinding.action)"
+            return "Request \(uniqueID) for user-initiated \(FeatureType.self) action \(ActionType.self)"
         } else {
-            return "Request \(uniqueID) for \(actionBinding.feature) action \(actionBinding.action)"
+            return "Request \(uniqueID) for \(FeatureType.self) action \(ActionType.self)"
         }
     }
 }

--- a/FlintCore/Actions/StaticActionBinding.swift
+++ b/FlintCore/Actions/StaticActionBinding.swift
@@ -33,18 +33,12 @@ import Foundation
 /// ```
 public struct StaticActionBinding<FeatureType, ActionType>: CustomDebugStringConvertible where FeatureType: FeatureDefinition, ActionType: Action {
 
-    /// The feature to which the action is bounc
-    public let feature: FeatureType.Type
-    
-    /// The action bound to the feature
-    public let action: ActionType.Type
-    
     private var _logTopicPath: TopicPath?
     /// The `TopicPath` to use when outputting logging for this action
     public var logTopicPath: TopicPath { return _logTopicPath! }
 
     private var session: ActionSession {
-        guard let result = action.defaultSession else {
+        guard let result = ActionType.defaultSession else {
             flintUsageError("You cannot call perform on action bindings directly unless the Action defines a value for defaultSession. Perhaps you mean your action to conform to UIAction, which uses the main session?")
         }
         return result
@@ -52,14 +46,12 @@ public struct StaticActionBinding<FeatureType, ActionType>: CustomDebugStringCon
     
     /// This initialiser is `internal` and must remain so to prevent misuse where static bindings could be created
     /// and directly performed even if they are only meant to be conditionally available.
-    init(feature: FeatureType.Type, action: ActionType.Type) {
-        self.feature = feature
-        self.action = action
+    init() {
         _logTopicPath = TopicPath(actionBinding: self)
     }
     
     public var debugDescription: String {
-        return "\(feature)'s action \(action)"
+        return "\(FeatureType.self)'s action \(ActionType.self)"
     }
 
     /// A convenience function to perform the action in the main `ActionSession`.

--- a/FlintCore/Activities/ActionActivityMappings.swift
+++ b/FlintCore/Activities/ActionActivityMappings.swift
@@ -48,7 +48,7 @@ class ActionActivityMappings {
     /// using `userInfo` and `activityType`.
     public static func createActivity<FeatureType, ActionType>(for actionBinding: StaticActionBinding<FeatureType, ActionType>,
                                                                with input: ActionType.InputType, appLink: URL? = nil) -> NSUserActivity? {
-        return createActivity(for: actionBinding.action, of: actionBinding.feature, with: input, appLink: appLink)
+        return createActivity(for: ActionType.self, of: FeatureType.self, with: input, appLink: appLink)
     }
     
     /// A helper function for creating an `NSUserActivity` that will invoke an action with a given input when received
@@ -61,7 +61,7 @@ class ActionActivityMappings {
     /// using `userInfo` and `activityType`.
     public static func createActivity<FeatureType, ActionType>(for actionBinding: ConditionalActionBinding<FeatureType, ActionType>,
                                                                with input: ActionType.InputType, appLink: URL? = nil) -> NSUserActivity? {
-        return createActivity(for: actionBinding.action, of: actionBinding.feature, with: input, appLink: appLink)
+        return createActivity(for: ActionType.self, of: FeatureType.self, with: input, appLink: appLink)
     }
     
     /// Interfnal function to create the activity.
@@ -104,7 +104,7 @@ class ActionActivityMappings {
             return
         }
 
-        let activityID = ActionActivityMappings.makeActivityID(forActionNamed: binding.action.name, of: binding.feature)
+        let activityID = ActionActivityMappings.makeActivityID(forActionNamed: ActionType.name, of: FeatureType.self)
 
         let executor: ActivityExecutor = { (activity, presentationRouter: PresentationRouter, source: ActionSource) -> ActionPerformOutcome in
             FlintInternal.logger?.debug("Executing activity \(activityID) with \(binding)")
@@ -141,7 +141,7 @@ class ActionActivityMappings {
             }
         }
 
-        addMapping(for: activityID, to: binding.action.name, executor: executor)
+        addMapping(for: activityID, to: ActionType.name, executor: executor)
     }
 
     /// Adds a mapping from an `activityType` ID to a conditional feature/action binding.
@@ -193,7 +193,7 @@ class ActionActivityMappings {
             }
         }
 
-        addMapping(for: activityID, to: binding.action.name, executor: executor)
+        addMapping(for: activityID, to: ActionType.name, executor: executor)
     }
 
     static func failedPresentationResultToActionPerformOutcome<T>(_ result: PresentationResult<T>) -> ActionPerformOutcome {

--- a/FlintCore/Activities/ActionActivityMappings.swift
+++ b/FlintCore/Activities/ActionActivityMappings.swift
@@ -151,7 +151,7 @@ class ActionActivityMappings {
             return
         }
         
-        let activityID = ActionActivityMappings.makeActivityID(forActionNamed: binding.action.name, of: binding.feature)
+        let activityID = ActionActivityMappings.makeActivityID(forActionNamed: ActionType.name, of: FeatureType.self)
 
         let executor: ActivityExecutor = { (activity, presentationRouter: PresentationRouter, source: ActionSource) -> ActionPerformOutcome in
             FlintInternal.logger?.debug("Executing activity \(activityID) with \(binding)")

--- a/FlintCore/Activities/ActivityActionDispatchObserver.swift
+++ b/FlintCore/Activities/ActivityActionDispatchObserver.swift
@@ -19,7 +19,7 @@ public class ActivityActionDispatchObserver: ActionDispatchObserver {
 
     public func actionDidComplete<FeatureType, ActionType>(_ request: ActionRequest<FeatureType, ActionType>, outcome: ActionPerformOutcome) {
         if outcome.isSuccess {
-            if request.actionBinding.action.activityTypes.count > 0 {
+            if ActionType.activityTypes.count > 0 {
                 registerUserActivity(for: request)
             }
         }
@@ -35,7 +35,7 @@ public class ActivityActionDispatchObserver: ActionDispatchObserver {
     /// nil. Returning non-nil from that function will result in a call to `actionActivity(for:)`.
     func registerUserActivity<FeatureType, ActionType>(for actionRequest: ActionRequest<FeatureType, ActionType>) {
         // Don't recurse into the activity actions
-        guard actionRequest.actionBinding.feature != ActivitiesFeature.self else {
+        guard FeatureType.self != ActivitiesFeature.self else {
             return
         }
         
@@ -45,7 +45,6 @@ public class ActivityActionDispatchObserver: ActionDispatchObserver {
         
         // Extract everything the action needs from the generic action request, as we cannot retain the type
         // information as we pass this forward to the action
-        let action = actionRequest.actionBinding.action
         let input = actionRequest.context.input
 
         var appLink: URL? = nil
@@ -71,7 +70,7 @@ public class ActivityActionDispatchObserver: ActionDispatchObserver {
                 appLink = linkCreator.appLink(to: actionRequest.actionBinding, with: validEncodable)
             } else {
                 if !(input is ActivityCodable) {
-                    flintUsageError("Input type \(type(of: input)) for action \(action.name) is not ActivityCodable, and " +
+                    flintUsageError("Input type \(type(of: input)) for action \(ActionType.name) is not ActivityCodable, and " +
                         "there is no Flint.linkCreator specified (are you missing a default custom URL scheme?). " +
                         "It will not be possible to continue this activity later.")
                 }
@@ -83,8 +82,8 @@ public class ActivityActionDispatchObserver: ActionDispatchObserver {
             return actionRequest.actionBinding.activity(for: input, withURL: appLink)
         }
 
-        let publishState = PublishActivityRequest(actionName: action.name,
-                                                feature: actionRequest.actionBinding.feature,
+        let publishState = PublishActivityRequest(actionName: ActionType.name,
+                                                feature: FeatureType.self,
                                                 activityCreator: prepareActivityWrapper,
                                                 appLink: appLink)
         DispatchQueue.main.async {

--- a/FlintCore/Analytics/AnalyticsReporting.swift
+++ b/FlintCore/Analytics/AnalyticsReporting.swift
@@ -32,22 +32,22 @@ public class AnalyticsReporting: ActionDispatchObserver {
     }
     
     public func actionWillBegin<FeatureType, ActionType>(_ request: ActionRequest<FeatureType, ActionType>) {
-        guard request.actionBinding.action.analyticsID != nil else {
+        guard ActionType.analyticsID != nil else {
             return
         }
-        let context = request.actionBinding.action.analyticsAttributes(for: request)
-        provider.analyticsEventWillBegin(feature: request.actionBinding.feature,
-                                         action: request.actionBinding.action,
+        let context =  ActionType.analyticsAttributes(for: request)
+        provider.analyticsEventWillBegin(feature: FeatureType.self,
+                                         action: ActionType.self,
                                          context: context)
     }
     
     public func actionDidComplete<FeatureType, ActionType>(_ request: ActionRequest<FeatureType, ActionType>, outcome: ActionPerformOutcome) {
-        guard request.actionBinding.action.analyticsID != nil else {
+        guard ActionType.analyticsID != nil else {
             return
         }
-        let context = request.actionBinding.action.analyticsAttributes(for: request)
-        provider.analyticsEventDidEnd(feature: request.actionBinding.feature,
-                                      action: request.actionBinding.action,
+        let context = ActionType.analyticsAttributes(for: request)
+        provider.analyticsEventDidEnd(feature: FeatureType.self,
+                                      action:  ActionType.self,
                                       context: context,
                                       outcome: outcome)
     }

--- a/FlintCore/Conditional Features/ConditionalActionBinding.swift
+++ b/FlintCore/Conditional Features/ConditionalActionBinding.swift
@@ -45,11 +45,9 @@ import Foundation
 /// with a conditional action, you must first request the conditional action using this binding, and then
 /// call perform with the `ConditionalActionRequest` received from that.
 public struct ConditionalActionBinding<FeatureType: ConditionalFeature, ActionType: Action>: CustomDebugStringConvertible {
-    public let feature: FeatureType.Type
-    public let action: ActionType.Type
 
     public var debugDescription: String {
-        return "ConditionalActionBinding action \(action) of \(feature)"
+        return "ConditionalActionBinding action \(ActionType.self) of \(FeatureType.self)"
     }
 
     /// Get a conditional action request if the feature of this binding is currently available.

--- a/FlintCore/Conditional Features/ConditionalFeature.swift
+++ b/FlintCore/Conditional Features/ConditionalFeature.swift
@@ -54,13 +54,13 @@ public extension ConditionalFeature {
     /// If so, returns a request that can be used to perform the action, otherwise `nil`.
     ///
     /// The default `isAvailable` implementation will delegate to the `AvailabilityChecker` to see if the feature is available.
-    public static func request<T>(_ actionBinding: ConditionalActionBinding<Self, T>) -> ConditionalActionRequest<Self, T>? {
+    public static func request<ActionType>(_ actionBinding: ConditionalActionBinding<Self, ActionType>) -> ConditionalActionRequest<Self, ActionType>? {
         // Sanity checks and footgun avoidance
         Flint.requiresSetup()
-        Flint.requiresPrepared(feature: actionBinding.feature)
+        Flint.requiresPrepared(feature: Self.self)
 
-        flintBugPrecondition(Flint.isDeclared(actionBinding.action, on: actionBinding.feature),
-                             "Action \(actionBinding.action) has not been declared on \(actionBinding.feature). Call 'declare' or 'publish' with it in your feature's prepare function.")
+        flintBugPrecondition(Flint.isDeclared(ActionType.self, on: Self.self),
+                             "Action \(ActionType.self) has not been declared on \(Self.self). Call 'declare' or 'publish' with it in your feature's prepare function.")
 
         /// The action is possible only if this feature is currently available
         guard let available = isAvailable, available == true else {
@@ -76,7 +76,7 @@ public extension ConditionalFeature {
                 reason.append(" Requires purchases: \(purchaseNames).")
             }
             /// TODO: Add info about preconditions
-            flintAdvisoryNotice("Request to use action '\(actionBinding.action.name)' on feature '\(actionBinding.feature.name)' denied.\(reason)")
+            flintAdvisoryNotice("Request to use action '\(ActionType.name)' on feature '\(Self.name)' denied.\(reason)")
             return nil
         }
         return ConditionalActionRequest(actionBinding: actionBinding)
@@ -85,8 +85,8 @@ public extension ConditionalFeature {
     /// Function for binding a conditional feature and action pair, to restrict how this can be done externally by app code.
     ///
     /// - note: This exists only in an extension as it is not an extension point for features to override.
-    public static func action<A>(_ action: A.Type) -> ConditionalActionBinding<Self, A> where A: Action {
-        return ConditionalActionBinding(feature: self, action: action)
+    public static func action<ActionType>(_ action: ActionType.Type) -> ConditionalActionBinding<Self, ActionType> where ActionType: Action {
+        return ConditionalActionBinding<Self, ActionType>()
     }
 }
 

--- a/FlintCore/Core/ActionDispatcher.swift
+++ b/FlintCore/Core/ActionDispatcher.swift
@@ -72,10 +72,8 @@ public class DefaultActionDispatcher: ActionDispatcher {
 
         // The action does *not* have to complete synchronously. We watch out for the cases where it doesn't and
         // log this for now. In future we will have a new outcome value indicating `completingAsynchronously`.
-        let action = request.actionBinding.action
-        
         // !!! TODO: This has to execute on the queue it is trying to capture. Is this a catch-22?
-        let smartActionQueue = SmartDispatchQueue(queue: action.queue)
+        let smartActionQueue = SmartDispatchQueue(queue: ActionType.queue)
         var performStatus: Action.Completion.Status?
         
         // Here we synchronously call the action on the queue it has requested, and we pass a completion object in
@@ -95,9 +93,9 @@ public class DefaultActionDispatcher: ActionDispatcher {
             }
 
             // Perform the action and get the immediate status of it
-            let status = action.perform(context: request.context,
-                                        presenter: request.presenter,
-                                        completion: completion)
+            let status = ActionType.perform(context: request.context,
+                                            presenter: request.presenter,
+                                            completion: completion)
             performStatus = status
             flintUsagePrecondition(completion.verify(status), "Action returned an invalid completion status")
         }

--- a/FlintCore/Core/ActionStackEntry.swift
+++ b/FlintCore/Core/ActionStackEntry.swift
@@ -41,8 +41,8 @@ public struct ActionStackEntry: CustomDebugStringConvertible {
     /// Initialise the entry capturing only simple types and without retaining anything from the request.
     init<FeatureType, ActionType>(_ request: ActionRequest<FeatureType, ActionType>, sessionName: String) {
         userInitiated = request.userInitiated
-        feature = request.actionBinding.feature
-        details = .action(name: request.actionBinding.action.name,
+        feature = FeatureType.self
+        details = .action(name: ActionType.name,
                           source: request.source,
                           input: String(reflecting: request.context.input))
         self.sessionName = sessionName

--- a/FlintCore/Core/ActionsBuilder.swift
+++ b/FlintCore/Core/ActionsBuilder.swift
@@ -20,85 +20,85 @@ class ActionsBuilder: FeatureActionsBuilder {
     }
     
     public func declare<FeatureType, ActionType>(_ binding: StaticActionBinding<FeatureType, ActionType>) {
-        Flint.bind(binding.action, to: feature)
+        Flint.bind(ActionType.self, to: FeatureType.self)
     }
     
     public func declare<FeatureType, ActionType>(_ binding: StaticActionBinding<FeatureType, ActionType>) where ActionType.InputType: ActivityCodable {
         activityMappings.registerActivity(for: binding)
-        Flint.bind(binding.action, to: feature)
+        Flint.bind(ActionType.self, to: FeatureType.self)
     }
     
     public func declare<FeatureType, ActionType>(_ binding: ConditionalActionBinding<FeatureType, ActionType>) {
-        Flint.bind(binding.action, to: feature)
+        Flint.bind(ActionType.self, to: FeatureType.self)
     }
 
     public func declare<FeatureType, ActionType>(_ binding: ConditionalActionBinding<FeatureType, ActionType>) where ActionType.InputType: ActivityCodable {
         activityMappings.registerActivity(for: binding)
-        Flint.bind(binding.action, to: feature)
+        Flint.bind(ActionType.self, to: FeatureType.self)
     }
 
     public func publish<FeatureType, ActionType>(_ binding: StaticActionBinding<FeatureType, ActionType>) {
-        Flint.publish(binding.action, to: feature)
+        Flint.publish(ActionType.self, to: FeatureType.self)
     }
-    
+
     public func publish<FeatureType, ActionType>(_ binding: StaticActionBinding<FeatureType, ActionType>) where ActionType.InputType: ActivityCodable {
         activityMappings.registerActivity(for: binding)
-        Flint.publish(binding.action, to: feature)
+        Flint.publish(ActionType.self, to: FeatureType.self)
     }
-
+    
     public func publish<FeatureType, ActionType>(_ binding: ConditionalActionBinding<FeatureType, ActionType>) {
-        Flint.publish(binding.action, to: feature)
+        Flint.publish(ActionType.self, to: FeatureType.self)
     }
 
+    
     public func publish<FeatureType, ActionType>(_ binding: ConditionalActionBinding<FeatureType, ActionType>) where ActionType.InputType: ActivityCodable {
         activityMappings.registerActivity(for: binding)
-        Flint.publish(binding.action, to: feature)
+        Flint.publish(ActionType.self, to: FeatureType.self)
     }
 
-#if canImport(Intents) && os(iOS)
-    @available(iOS 12, *)
-    public func declare<FeatureType, ActionType>(_ binding: StaticActionBinding<FeatureType, ActionType>) where ActionType: IntentAction {
-        Flint.bind(binding.action, to: feature)
-    }
-
+#if canImport(Network) && os(iOS)
     @available(iOS 12, *)
     public func declare<FeatureType, ActionType>(_ binding: StaticActionBinding<FeatureType, ActionType>) where ActionType: IntentAction, ActionType.InputType: ActivityCodable {
         activityMappings.registerActivity(for: binding)
-        Flint.bind(binding.action, to: feature)
+        Flint.bind(ActionType.self, to: FeatureType.self)
     }
     
     @available(iOS 12, *)
     public func declare<FeatureType, ActionType>(_ binding: ConditionalActionBinding<FeatureType, ActionType>) where ActionType: IntentAction {
-        Flint.bind(binding.action, to: feature)
+        Flint.bind(ActionType.self, to: FeatureType.self)
     }
 
     @available(iOS 12, *)
     public func declare<FeatureType, ActionType>(_ binding: ConditionalActionBinding<FeatureType, ActionType>) where ActionType: IntentAction, ActionType.InputType: ActivityCodable {
         activityMappings.registerActivity(for: binding)
-        Flint.bind(binding.action, to: feature)
+        Flint.bind(ActionType.self, to: FeatureType.self)
     }
 
     @available(iOS 12, *)
     public func publish<FeatureType, ActionType>(_ binding: StaticActionBinding<FeatureType, ActionType>) where ActionType: IntentAction {
-        Flint.publish(binding.action, to: feature)
+        Flint.publish(ActionType.self, to: FeatureType.self)
+    }
+    
+    @available(iOS 12, *)
+    public func declare<FeatureType, ActionType>(_ binding: StaticActionBinding<FeatureType, ActionType>) where ActionType: IntentAction {
+        Flint.bind(ActionType.self, to: FeatureType.self)
     }
     
     @available(iOS 12, *)
     public func publish<FeatureType, ActionType>(_ binding: StaticActionBinding<FeatureType, ActionType>) where ActionType: IntentAction, ActionType.InputType: ActivityCodable {
         activityMappings.registerActivity(for: binding)
-        Flint.publish(binding.action, to: feature)
+        Flint.publish(ActionType.self, to: FeatureType.self)
     }
     
     @available(iOS 12, *)
     public func publish<FeatureType, ActionType>(_ binding: ConditionalActionBinding<FeatureType, ActionType>) where ActionType: IntentAction {
-        Flint.publish(binding.action, to: feature)
+        Flint.publish(ActionType.self, to: FeatureType.self)
     }
 
     @available(iOS 12, *)
     public func publish<FeatureType, ActionType>(_ binding: ConditionalActionBinding<FeatureType, ActionType>) where ActionType: IntentAction, ActionType.InputType: ActivityCodable {
         activityMappings.registerActivity(for: binding)
-        Flint.publish(binding.action, to: feature)
+        Flint.publish(ActionType.self, to: FeatureType.self)
     }
 #endif
-
 }

--- a/FlintCore/Core/Flint.swift
+++ b/FlintCore/Core/Flint.swift
@@ -108,6 +108,14 @@ final public class Flint {
         }
     }
 
+    /// Get the metadata for the specified action binding
+    public static func metadata<FeatureType, ActionType>(for action: StaticActionBinding<FeatureType,ActionType>) -> ActionMetadata? {
+        guard let featureMetadata = metadata(for: FeatureType.self) else {
+            flintUsageError("Cannot get metadata for feature \(FeatureType.self), feature not registered.")
+        }
+        return featureMetadata.actionMetadata(action: ActionType.self)
+    }
+
     // MARK: Setup and convenience functions
     
     /// Call for the default setup of loggers, link creation, automatic logging of action start/end.

--- a/FlintCore/Core/TopicPath+Extensions.swift
+++ b/FlintCore/Core/TopicPath+Extensions.swift
@@ -15,10 +15,10 @@ public extension TopicPath {
     }
 
     init<FeatureType, ActionType>(actionBinding: StaticActionBinding<FeatureType, ActionType>) {
-        self.init(actionBinding.feature.identifier.path + ["#\(String(describing: actionBinding.action))"])
+        self.init(FeatureType.identifier.path + ["#\(String(describing: ActionType.self))"])
     }
 
     init<FeatureType, ActionType>(actionBinding: ConditionalActionBinding<FeatureType, ActionType>) {
-        self.init(actionBinding.feature.identifier.path + ["#\(String(describing: actionBinding.action))"])
+        self.init(FeatureType.identifier.path + ["#\(String(describing: ActionType.self))"])
     }
 }

--- a/FlintCore/Features/Feature.swift
+++ b/FlintCore/Features/Feature.swift
@@ -53,14 +53,14 @@ public extension Feature {
 
     /// Function for binding a feature and action pair, to restrict how this can be done externally by app code.
     public static func action<ActionType>(_ action: ActionType.Type) -> StaticActionBinding<Self, ActionType> {
-        return StaticActionBinding(feature: self, action: action)
+        return StaticActionBinding<Self, ActionType>()
     }
 
     /// Function for binding a feature and action pair, to restrict how this can be done externally by app code.
 #if canImport(Intents) && os(iOS)
     @available(iOS 12, *)
     public static func action<ActionType>(_ action: ActionType.Type) -> StaticActionBinding<Self, ActionType> where ActionType: IntentAction {
-        return StaticActionBinding(feature: self, action: action)
+        return StaticActionBinding<Self, ActionType>()
     }
 #endif
 }

--- a/FlintCore/Routes/LinkCreator.swift
+++ b/FlintCore/Routes/LinkCreator.swift
@@ -43,7 +43,7 @@ public class LinkCreator {
         guard let scheme = defaultScheme else {
             flintUsageError("No app URL scheme available")
         }
-        guard let mappings = ActionURLMappings.instance.mappings(for: actionBinding.feature, action: actionBinding.action.name) else {
+        guard let mappings = ActionURLMappings.instance.mappings(for: FeatureType.self, action: ActionType.name) else {
             flintUsageError("No URL mapping exists for: \(actionBinding)")
         }
         let matchedMapping = mappings.first { $0.scope.isApp }
@@ -60,7 +60,7 @@ public class LinkCreator {
         guard let scheme = defaultScheme else {
             flintUsageError("No app URL scheme available")
         }
-        guard let mappings = ActionURLMappings.instance.mappings(for: actionBinding.feature, action: actionBinding.action.name) else {
+        guard let mappings = ActionURLMappings.instance.mappings(for: FeatureType.self, action: ActionType.name) else {
             flintUsageError("No URL mapping exists for: \(actionBinding)")
         }
         let matchedMapping = mappings.first { $0.scope.isApp }
@@ -77,7 +77,7 @@ public class LinkCreator {
         guard let domain = defaultDomain else {
             flintUsageError("No associated domain available")
         }
-        guard let mappings = ActionURLMappings.instance.mappings(for: actionBinding.feature, action: actionBinding.action.name) else {
+        guard let mappings = ActionURLMappings.instance.mappings(for: FeatureType.self, action: ActionType.name) else {
             flintUsageError("No URL mapping exists for: \(actionBinding)")
         }
         let matchedMapping = mappings.first { $0.scope.isUniversal }
@@ -94,7 +94,7 @@ public class LinkCreator {
         guard let domain = defaultDomain else {
             flintUsageError("No associated domain available")
         }
-        guard let mappings = ActionURLMappings.instance.mappings(for: actionBinding.feature, action: actionBinding.action.name) else {
+        guard let mappings = ActionURLMappings.instance.mappings(for: FeatureType.self, action: ActionType.name) else {
             flintUsageError("No URL mapping exists for: \(actionBinding)")
         }
         let matchedMapping = mappings.first { $0.scope.isUniversal }
@@ -113,7 +113,7 @@ public class LinkCreator {
         guard let scheme = defaultScheme else {
             flintUsageError("No app URL scheme available")
         }
-        guard let mappings = ActionURLMappings.instance.mappings(for: actionBinding.feature, action: actionBinding.action.name) else {
+        guard let mappings = ActionURLMappings.instance.mappings(for: FeatureType.self, action: ActionType.name) else {
             flintUsageError("No URL mapping exists for: \(actionBinding)")
         }
         let matchedMapping = mappings.first { $0.scope.isApp }

--- a/FlintCore/Routes/URLMappingsBuilder.swift
+++ b/FlintCore/Routes/URLMappingsBuilder.swift
@@ -102,14 +102,14 @@ public class URLMappingsBuilder {
         }
         
         FlintInternal.urlMappingLogger?.debug("Adding URL mapping \(mapping) ➡️ \(actionBinding)")
-        mappings.add(mapping, actionType: actionBinding.action)
+        mappings.add(mapping, actionType: ActionType.self)
         
         // This is a bit funky doing this inside the builder, we should really take the results of the build and
         // iterate over them to add them to the actual url mapping subsystem. However this means introducing a new
         // type to contain the feature, action and executor info.
         /// !!! TODO: Introduce a new `URLMappingExecutorBinding` type and use this in `URLMappings` and return here,
         /// letting the caller iterate over the mappings and bind them to the `ActionURLMappings`
-        ActionURLMappings.instance.add(mapping: mapping, for: actionBinding.feature, actionName: actionBinding.action.name, executor: executor)
+        ActionURLMappings.instance.add(mapping: mapping, for: FeatureType.self, actionName: ActionType.name, executor: executor)
     }
     
     /// Create the mapping and register with the global mappings table. Similar but not idential to above, because
@@ -138,13 +138,13 @@ public class URLMappingsBuilder {
         }
 
         FlintInternal.urlMappingLogger?.debug("Adding URL mapping \(mapping) ➡️ \(actionBinding)")
-        mappings.add(mapping, actionType: actionBinding.action)
+        mappings.add(mapping, actionType: ActionType.self)
 
         // This is a bit funky doing this inside the builder, we should really take the results of the build and
         // iterate over them to add them to the actual url mapping subsystem. However this means introducing a new
         // type to contain the feature, action and executor info.
         /// !!! TODO: Introduce a new `URLMappingExecutorBinding` type and use this in `URLMappings` and return here,
         /// letting the caller iterate over the mappings and bind them to the `ActionURLMappings`
-        ActionURLMappings.instance.add(mapping: mapping, for: actionBinding.feature, actionName: actionBinding.action.name, executor: executor)
+        ActionURLMappings.instance.add(mapping: mapping, for: FeatureType.self, actionName: ActionType.name, executor: executor)
     }
 }

--- a/FlintCore/Siri Intents and Shortcuts/SiriShortcutDonatingActionDispatchObserver.swift
+++ b/FlintCore/Siri Intents and Shortcuts/SiriShortcutDonatingActionDispatchObserver.swift
@@ -23,18 +23,16 @@ class SiriShortcutDonatingActionDispatchObserver: ActionDispatchObserver {
     }
     
     func actionDidComplete<FeatureType, ActionType>(_ request: ActionRequest<FeatureType, ActionType>, outcome: ActionPerformOutcome) where FeatureType : FeatureDefinition, ActionType : Action {
-        if #available(iOS 12.0, *) {
-            guard let intents = request.actionBinding.action.associatedIntents(for: request.context.input) else {
-                loggers.development?.debug("Action completed but did not return an intent to donate: \(request)")
-                return
-            }
-            for intent in intents {
-                if let actionRequest = IntentShortcutDonationFeature.donateShortcut.request() {
-                    loggers.development?.debug("Action \(request.actionBinding.action) completed and returned an Intent to donate: \(intent)")
-                    actionRequest.perform(input: FlintIntentWrapper(intent: intent))
-                } else {
-                    loggers.development?.debug("Action \(request.actionBinding.action) completed and has an intent to donate but the donation feature is not enabled")
-                }
+        guard let intents = ActionType.associatedIntents(for: request.context.input) else {
+            loggers.development?.debug("Action completed but did not return an intent to donate: \(request)")
+            return
+        }
+        for intent in intents {
+            if let actionRequest = IntentShortcutDonationFeature.donateShortcut.request() {
+                loggers.development?.debug("Action \(ActionType.self) completed and returned an Intent to donate: \(intent)")
+                actionRequest.perform(input: FlintIntentWrapper(intent: intent))
+            } else {
+                loggers.development?.debug("Action \(ActionType.self) completed and has an intent to donate but the donation feature is not enabled")
             }
         }
     }

--- a/FlintCore/Siri Intents and Shortcuts/StaticActionBinding+Shortcut+Extensions.swift
+++ b/FlintCore/Siri Intents and Shortcuts/StaticActionBinding+Shortcut+Extensions.swift
@@ -67,8 +67,8 @@ extension StaticActionBinding where ActionType: IntentAction {
     /// Donate an intent-based shortcut that will invoke this `Action` to Siri for the given input.
     @available(iOS 12, *)
     public func donateToSiri(for input: ActionType.InputType) {
-        guard let intent = action.intent(for: input) else {
-            flintUsageError("Cannot donate intent to Siri, action type \(action) did not return an intent for input: \(input).")
+        guard let intent = ActionType.intent(for: input) else {
+            flintUsageError("Cannot donate intent to Siri, action type \(ActionType.self) did not return an intent for input: \(input).")
         }
         if let request = IntentShortcutDonationFeature.donateShortcut.request() {
             let intentWrapper = FlintIntentWrapper(intent: intent)

--- a/FlintCore/Timeline/Timeline.swift
+++ b/FlintCore/Timeline/Timeline.swift
@@ -37,10 +37,10 @@ public class Timeline: ActionDispatchObserver, DebugReportable {
     // MARK: Observing the action dispatcher
     
     public func actionWillBegin<FeatureType, ActionType>(_ request: ActionRequest<FeatureType, ActionType>) {
-        guard !request.actionBinding.action.hideFromTimeline else {
+        guard !ActionType.hideFromTimeline else {
             return
         }
-        guard !(FocusFeature.dependencies.focusSelection?.shouldSuppress(feature: request.actionBinding.feature) == true) else {
+        guard !(FocusFeature.dependencies.focusSelection?.shouldSuppress(feature: FeatureType.self) == true) else {
             return
         }
         let entry = TimelineEntry(sequenceID: request.uniqueID,
@@ -48,18 +48,18 @@ public class Timeline: ActionDispatchObserver, DebugReportable {
                                   source: request.source,
                                   date: Date(),
                                   sessionName: request.sessionName,
-                                  feature: request.actionBinding.feature,
-                                  actionName: request.actionBinding.action.name,
+                                  feature: FeatureType.self,
+                                  actionName: ActionType.name,
                                   inputDescription: request.context.input.loggingDescription,
                                   inputInfo: request.context.input.loggingInfo)
         entries.append(entry)
     }
     
     public func actionDidComplete<FeatureType, ActionType>(_ request: ActionRequest<FeatureType, ActionType>, outcome: ActionPerformOutcome) {
-        guard !request.actionBinding.action.hideFromTimeline else {
+        guard !ActionType.hideFromTimeline else {
             return
         }
-        guard !(FocusFeature.dependencies.focusSelection?.shouldSuppress(feature: request.actionBinding.feature) == true) else {
+        guard !(FocusFeature.dependencies.focusSelection?.shouldSuppress(feature: FeatureType.self) == true) else {
             return
         }
         let entry = TimelineEntry(sequenceID: request.uniqueID,
@@ -67,8 +67,8 @@ public class Timeline: ActionDispatchObserver, DebugReportable {
                                   source: request.source,
                                   date: Date(),
                                   sessionName: request.sessionName,
-                                  feature: request.actionBinding.feature,
-                                  actionName: request.actionBinding.action.name,
+                                  feature: FeatureType.self,
+                                  actionName: ActionType.name,
                                   inputDescription: request.context.input.loggingDescription,
                                   inputInfo: request.context.input.loggingInfo,
                                   outcome: outcome.simplifiedOutcome)

--- a/FlintCoreTests/IntentBindingTests.swift
+++ b/FlintCoreTests/IntentBindingTests.swift
@@ -23,14 +23,11 @@ class IntentBindingTests: XCTestCase {
     /// Verify that action metadata includes the Intent if any for intent actions
     func testIntentMetadataBinding() {
         if #available(iOS 12, *) {
-            guard let metadata = Flint.metadata(for: DummyFeature.self) else {
-                fatalError("Expected metadata for test feature")
-            }
-            guard let actionMetadata = metadata.actionMetadata(action: DummyFeature.intentAction.action) else {
-                fatalError("Expected metadata for test action")
+            guard let metadata = Flint.metadata(for: DummyFeature.intentAction) else {
+                fatalError("Expected metadata for test action binding")
             }
             let intentTypeName = String(reflecting: DummyIntent.self)
-            XCTAssertEqual(actionMetadata.intentTypeName, intentTypeName, "Intent type was not found in action metadata")
+            XCTAssertEqual(metadata.intentTypeName, intentTypeName, "Intent type was not found in action metadata")
         }
     }
 


### PR DESCRIPTION
Remove the references to Feature and Action types in the binding. All functions at access a binding are by their nature generic over these types, so the type info is always available.

This actually makes the code a bit cleaner.