### PR TITLE
Fix description of URL routes in debug Feature Browser UI

### DIFF
--- a/FlintCore/Actions/ActionMetadata.swift
+++ b/FlintCore/Actions/ActionMetadata.swift
@@ -35,7 +35,7 @@ public class ActionMetadata {
     }
     
     func add(urlMapping: URLMapping) {
-        urlMappings.append(urlMapping.debugDescription)
+        urlMappings.append(urlMapping.description)
     }
     
     func setIntent(_ intent: FlintIntent.Type) {

--- a/FlintCore/Routes/URLMapping.swift
+++ b/FlintCore/Routes/URLMapping.swift
@@ -15,7 +15,7 @@ public struct URLMappingResult {
 
 
 /// A struct used to represent a route scope and path mapping to an action
-public struct URLMapping: Hashable, Equatable, CustomDebugStringConvertible {
+public struct URLMapping: Hashable, Equatable, CustomStringConvertible, CustomDebugStringConvertible {
     let name: String?
     let scope: RouteScope
     let pattern: AnyURLPattern
@@ -72,7 +72,21 @@ public struct URLMapping: Hashable, Equatable, CustomDebugStringConvertible {
             lhs.name == rhs.name
     }
     
+    public var description: String {
+        var result = "/\(pattern.urlPattern)"
+        switch scope {
+            case .appAny: result.append(" in all app schemes")
+            case .universalAny: result.append(" in all associated domains")
+            case .app(let scheme): result.append(" in app scheme \(scheme)")
+            case .universal(let domain): result.append(" in associated domain \(domain)")
+        }
+        if let name = name {
+            result.append(" with name \(name)")
+        }
+        return result
+    }
+    
     public var debugDescription: String {
-        return "\(pattern.urlPattern) in \(scope) with name \(name ?? "<none>")"
+        return "/\(pattern.urlPattern) in \(scope) with name \(name ?? "<none>")"
     }
 }

--- a/FlintUISandbox/FakeFeatures.swift
+++ b/FlintUISandbox/FakeFeatures.swift
@@ -33,7 +33,7 @@ final class FakeFeature: ConditionalFeature, URLMapped {
     }
     
     static func urlMappings(routes: URLMappingsBuilder) {
-        routes.send("/test", to: action1)
+        routes.send("test", to: action1)
     }
 }
 


### PR DESCRIPTION
It now looks like this, more human-readable.

<img width="416" alt="screenshot 2019-02-10 at 21 35 01" src="https://user-images.githubusercontent.com/40849/52539944-d6d4ac00-2d7b-11e9-8b1c-5ba5792468e3.png">
