### PR TITLE
Purchase API improvements

### DIFF
--- a/FlintCore.xcodeproj/project.pbxproj
+++ b/FlintCore.xcodeproj/project.pbxproj
@@ -234,6 +234,26 @@
 		495768B6200E629C00CB2E6F /* LinkCreator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495768B5200E629C00CB2E6F /* LinkCreator.swift */; };
 		495B6C69202B60A50024CDFB /* FlintAppInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495B6C68202B60A50024CDFB /* FlintAppInfo.swift */; };
 		495B6C70202BC9280024CDFB /* Flint.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495B6C6F202BC9280024CDFB /* Flint.swift */; };
+		495CBD8A223D6E1E00233816 /* NonConsumableProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495CBD85223D6C1D00233816 /* NonConsumableProduct.swift */; };
+		495CBD8B223D6E1E00233816 /* ConsumableProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495CBD88223D6C2400233816 /* ConsumableProduct.swift */; };
+		495CBD8C223D6E1E00233816 /* SubscriptionProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495CBD86223D6C1F00233816 /* SubscriptionProduct.swift */; };
+		495CBD8D223D6E1E00233816 /* AutoRenewingSubscriptionProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495CBD87223D6C2100233816 /* AutoRenewingSubscriptionProduct.swift */; };
+		495CBD8E223D6E1E00233816 /* NonRenewingSubscriptionProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495CBD89223D6C2600233816 /* NonRenewingSubscriptionProduct.swift */; };
+		495CBD8F223D6E1F00233816 /* NonConsumableProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495CBD85223D6C1D00233816 /* NonConsumableProduct.swift */; };
+		495CBD90223D6E1F00233816 /* ConsumableProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495CBD88223D6C2400233816 /* ConsumableProduct.swift */; };
+		495CBD91223D6E1F00233816 /* SubscriptionProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495CBD86223D6C1F00233816 /* SubscriptionProduct.swift */; };
+		495CBD92223D6E1F00233816 /* AutoRenewingSubscriptionProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495CBD87223D6C2100233816 /* AutoRenewingSubscriptionProduct.swift */; };
+		495CBD93223D6E1F00233816 /* NonRenewingSubscriptionProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495CBD89223D6C2600233816 /* NonRenewingSubscriptionProduct.swift */; };
+		495CBD94223D6E2000233816 /* NonConsumableProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495CBD85223D6C1D00233816 /* NonConsumableProduct.swift */; };
+		495CBD95223D6E2000233816 /* ConsumableProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495CBD88223D6C2400233816 /* ConsumableProduct.swift */; };
+		495CBD96223D6E2000233816 /* SubscriptionProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495CBD86223D6C1F00233816 /* SubscriptionProduct.swift */; };
+		495CBD97223D6E2000233816 /* AutoRenewingSubscriptionProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495CBD87223D6C2100233816 /* AutoRenewingSubscriptionProduct.swift */; };
+		495CBD98223D6E2000233816 /* NonRenewingSubscriptionProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495CBD89223D6C2600233816 /* NonRenewingSubscriptionProduct.swift */; };
+		495CBD99223D6E2100233816 /* NonConsumableProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495CBD85223D6C1D00233816 /* NonConsumableProduct.swift */; };
+		495CBD9A223D6E2100233816 /* ConsumableProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495CBD88223D6C2400233816 /* ConsumableProduct.swift */; };
+		495CBD9B223D6E2100233816 /* SubscriptionProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495CBD86223D6C1F00233816 /* SubscriptionProduct.swift */; };
+		495CBD9C223D6E2100233816 /* AutoRenewingSubscriptionProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495CBD87223D6C2100233816 /* AutoRenewingSubscriptionProduct.swift */; };
+		495CBD9D223D6E2100233816 /* NonRenewingSubscriptionProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495CBD89223D6C2600233816 /* NonRenewingSubscriptionProduct.swift */; };
 		495EED7421FA8065001142A0 /* LogFileNamingStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495EED7321FA8065001142A0 /* LogFileNamingStrategy.swift */; };
 		495EED7621FA80A9001142A0 /* TimestampLogFileNamingStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495EED7521FA80A9001142A0 /* TimestampLogFileNamingStrategy.swift */; };
 		495EED7721FA80A9001142A0 /* TimestampLogFileNamingStrategy.swift in Sources */ = {isa = PBXBuildFile; fileRef = 495EED7521FA80A9001142A0 /* TimestampLogFileNamingStrategy.swift */; };
@@ -927,6 +947,11 @@
 		495768B5200E629C00CB2E6F /* LinkCreator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LinkCreator.swift; sourceTree = "<group>"; };
 		495B6C68202B60A50024CDFB /* FlintAppInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlintAppInfo.swift; sourceTree = "<group>"; };
 		495B6C6F202BC9280024CDFB /* Flint.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Flint.swift; sourceTree = "<group>"; };
+		495CBD85223D6C1D00233816 /* NonConsumableProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonConsumableProduct.swift; sourceTree = "<group>"; };
+		495CBD86223D6C1F00233816 /* SubscriptionProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SubscriptionProduct.swift; sourceTree = "<group>"; };
+		495CBD87223D6C2100233816 /* AutoRenewingSubscriptionProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AutoRenewingSubscriptionProduct.swift; sourceTree = "<group>"; };
+		495CBD88223D6C2400233816 /* ConsumableProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsumableProduct.swift; sourceTree = "<group>"; };
+		495CBD89223D6C2600233816 /* NonRenewingSubscriptionProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NonRenewingSubscriptionProduct.swift; sourceTree = "<group>"; };
 		495EED7321FA8065001142A0 /* LogFileNamingStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogFileNamingStrategy.swift; sourceTree = "<group>"; };
 		495EED7521FA80A9001142A0 /* TimestampLogFileNamingStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TimestampLogFileNamingStrategy.swift; sourceTree = "<group>"; };
 		495EED7A21FA80DE001142A0 /* LogEventFormattingStrategy.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LogEventFormattingStrategy.swift; sourceTree = "<group>"; };
@@ -1701,6 +1726,11 @@
 			children = (
 				49040A162224236300E5104D /* StoreKit-Specific */,
 				49DB923D2073B4F500F758DC /* Product.swift */,
+				495CBD85223D6C1D00233816 /* NonConsumableProduct.swift */,
+				495CBD88223D6C2400233816 /* ConsumableProduct.swift */,
+				495CBD86223D6C1F00233816 /* SubscriptionProduct.swift */,
+				495CBD87223D6C2100233816 /* AutoRenewingSubscriptionProduct.swift */,
+				495CBD89223D6C2600233816 /* NonRenewingSubscriptionProduct.swift */,
 				49966D92200A644A004C4AA0 /* PurchaseTracker.swift */,
 				49891EB12094BEB600B9BCBF /* PurchaseTrackerObserver.swift */,
 				49DB92422073C67900F758DC /* PurchaseRequirement.swift */,
@@ -2074,6 +2104,7 @@
 				49137FF420CF29C500C696F4 /* Action+Extensions.swift in Sources */,
 				496F8FC7203EEBDA003AB29B /* ActionStackEntry.swift in Sources */,
 				496F8F55203EEBB1003AB29B /* TimelineEntry.swift in Sources */,
+				495CBD90223D6E1F00233816 /* ConsumableProduct.swift in Sources */,
 				4929823D205ED12C00267A49 /* ActionMetadata.swift in Sources */,
 				494F59162098AA280075E7EE /* PlatformVersionConstraint.swift in Sources */,
 				498A894D2068FF5200457D66 /* TimelineFeature.swift in Sources */,
@@ -2102,6 +2133,7 @@
 				496136D52099015900291885 /* LocationPermissionAdapter.swift in Sources */,
 				498F976F207783C500209633 /* FocusLogging.swift in Sources */,
 				496F8FD6203EEBDA003AB29B /* FlintInternal.swift in Sources */,
+				495CBD92223D6E1F00233816 /* AutoRenewingSubscriptionProduct.swift in Sources */,
 				4956D5D520986BDE002A2A35 /* FeatureConstraintsBuilder.swift in Sources */,
 				49FC460A20A4795D00679F97 /* PerformIncomingURLAction.swift in Sources */,
 				496F8F82203EEBBA003AB29B /* ConditionalActionBinding.swift in Sources */,
@@ -2119,6 +2151,7 @@
 				494C27A420C01CE400053FF7 /* MotionPermissionAdapter.swift in Sources */,
 				496136D02099013000291885 /* PhotosPermissionAdapter.swift in Sources */,
 				49DFB7CB20A2DFA600D3AE68 /* DefaultAuthorisationController.swift in Sources */,
+				495CBD8F223D6E1F00233816 /* NonConsumableProduct.swift in Sources */,
 				4946FAC6208E23740097E10E /* ActionPerformOutcome.swift in Sources */,
 				496F8F5B203EEBB1003AB29B /* DefaultContextSpecificLogger.swift in Sources */,
 				496136B22099004A00291885 /* SystemPermissionConstraint.swift in Sources */,
@@ -2133,6 +2166,7 @@
 				496F8F80203EEBBA003AB29B /* ConditionalFeatureDefinition.swift in Sources */,
 				496F8F4B203EEBA5003AB29B /* AnalyticsReporting.swift in Sources */,
 				49FC45FB20A46F0900679F97 /* MappedActionResult.swift in Sources */,
+				495CBD91223D6E1F00233816 /* SubscriptionProduct.swift in Sources */,
 				493267532142FA0E00CC88CB /* Archive+Writing.swift in Sources */,
 				4905C5D022105CF400890C11 /* DebugPurchaseTracker.swift in Sources */,
 				496F8F4A203EEBA5003AB29B /* ObserverSet.swift in Sources */,
@@ -2162,6 +2196,7 @@
 				494F59112098AA140075E7EE /* OperatingSystemVersion+Utilities.swift in Sources */,
 				494F590C2098A9F70075E7EE /* Platform.swift in Sources */,
 				496F8F53203EEBB1003AB29B /* ActionLoggingDispatchObserver.swift in Sources */,
+				495CBD93223D6E1F00233816 /* NonRenewingSubscriptionProduct.swift in Sources */,
 				494F59202098AA5D0075E7EE /* DeclaredFeatureConstraints.swift in Sources */,
 				496F8F4C203EEBA5003AB29B /* ConsoleAnalyticsProvider.swift in Sources */,
 				4980005720B3621200D68321 /* URLExecutionContext.swift in Sources */,
@@ -2286,6 +2321,7 @@
 				496F8FDC203EEBDA003AB29B /* ActionStackEntry.swift in Sources */,
 				496F8F64203EEBB2003AB29B /* TimelineEntry.swift in Sources */,
 				4929823E205ED12C00267A49 /* ActionMetadata.swift in Sources */,
+				495CBD94223D6E2000233816 /* NonConsumableProduct.swift in Sources */,
 				494F59172098AA280075E7EE /* PlatformVersionConstraint.swift in Sources */,
 				498A894E2068FF5200457D66 /* TimelineFeature.swift in Sources */,
 				494F59492098ABE90075E7EE /* DefaultFeatureConstraintsEvaluator.swift in Sources */,
@@ -2318,6 +2354,7 @@
 				496F8F8B203EEBBB003AB29B /* ConditionalActionBinding.swift in Sources */,
 				496F8F9D203EEBC5003AB29B /* RoutesFeature.swift in Sources */,
 				4927FEF0208A3B7C00163576 /* ActivityType.swift in Sources */,
+				495CBD98223D6E2000233816 /* NonRenewingSubscriptionProduct.swift in Sources */,
 				496F8FB9203EEBD4003AB29B /* RouteScope.swift in Sources */,
 				499FE34420BD892900552CE9 /* DefaultFeatureConstraintEvaluationResults.swift in Sources */,
 				49FC45FF20A46F1A00679F97 /* ActionContext.swift in Sources */,
@@ -2335,6 +2372,7 @@
 				496136B32099004A00291885 /* SystemPermissionConstraint.swift in Sources */,
 				496F8F66203EEBB2003AB29B /* ContextualLoggerTarget.swift in Sources */,
 				496F8FB6203EEBD4003AB29B /* URLMapping.swift in Sources */,
+				495CBD96223D6E2000233816 /* SubscriptionProduct.swift in Sources */,
 				496136BD209900BC00291885 /* SystemPermissionChecker.swift in Sources */,
 				4921705D20D25625007D6883 /* ActivityCodable.swift in Sources */,
 				496F8FE9203EEBDA003AB29B /* StaticActionBinding.swift in Sources */,
@@ -2368,6 +2406,7 @@
 				4956D5DB209895C2002A2A35 /* UserFeatureTogglesObserver.swift in Sources */,
 				4921706720D27D14007D6883 /* FlintImage.swift in Sources */,
 				493267592142FA2B00CC88CB /* Archive.swift in Sources */,
+				495CBD97223D6E2000233816 /* AutoRenewingSubscriptionProduct.swift in Sources */,
 				49BC1C4720795E9E00A7FC77 /* LIFOArrayQueueDataSource.swift in Sources */,
 				494F59122098AA140075E7EE /* OperatingSystemVersion+Utilities.swift in Sources */,
 				494F590D2098A9F70075E7EE /* Platform.swift in Sources */,
@@ -2410,6 +2449,7 @@
 				49298239205ED11900267A49 /* FeatureMetadata.swift in Sources */,
 				496F8F6B203EEBB2003AB29B /* FocusContextualLoggerTarget.swift in Sources */,
 				4905C5C722104C4B00890C11 /* SimplePurchaseStore.swift in Sources */,
+				495CBD95223D6E2000233816 /* ConsumableProduct.swift in Sources */,
 				49DB926220757D9500F758DC /* AnalyticsProvider.swift in Sources */,
 				496F8F6E203EEBB2003AB29B /* LoggerLevel.swift in Sources */,
 				499FE34920BD89C400552CE9 /* FeatureConstraintEvaluationResults.swift in Sources */,
@@ -2473,6 +2513,7 @@
 				496F8F77203EEBB3003AB29B /* ContextSpecificLogger.swift in Sources */,
 				49DFB7CD20A2DFA600D3AE68 /* DefaultAuthorisationController.swift in Sources */,
 				496F8FFB203EEBDB003AB29B /* NoInput.swift in Sources */,
+				495CBD99223D6E2100233816 /* NonConsumableProduct.swift in Sources */,
 				49A62C8620D2FDF800264606 /* PerformIncomingActivityAction.swift in Sources */,
 				494F59402098ABB20075E7EE /* UserTogglePreconditionEvaluator.swift in Sources */,
 				4956D5DC209895C2002A2A35 /* UserFeatureTogglesObserver.swift in Sources */,
@@ -2547,6 +2588,7 @@
 				496F8FFF203EEBDB003AB29B /* TopicPath+Extensions.swift in Sources */,
 				496F8F79203EEBB3003AB29B /* DefaultContextSpecificLogger.swift in Sources */,
 				496F8F75203EEBB3003AB29B /* ContextualLoggerTarget.swift in Sources */,
+				495CBD9A223D6E2100233816 /* ConsumableProduct.swift in Sources */,
 				49FC460F20A488D000679F97 /* InternalJSONFormatting.swift in Sources */,
 				49DB92412073B4F600F758DC /* Product.swift in Sources */,
 				49298235205ED0D900267A49 /* FeatureActionsBuilder.swift in Sources */,
@@ -2578,9 +2620,11 @@
 				496F8F95203EEBBC003AB29B /* AvailabilityChecker.swift in Sources */,
 				496F8F72203EEBB2003AB29B /* Timeline.swift in Sources */,
 				4927FEFB208A537100163576 /* PublishCurrentActionActivityAction.swift in Sources */,
+				495CBD9C223D6E2100233816 /* AutoRenewingSubscriptionProduct.swift in Sources */,
 				496136C8209900E200291885 /* CameraPermissionAdapter.swift in Sources */,
 				498F976C2077832F00209633 /* DefaultFocusSelection.swift in Sources */,
 				4980005920B3621200D68321 /* URLExecutionContext.swift in Sources */,
+				495CBD9D223D6E2100233816 /* NonRenewingSubscriptionProduct.swift in Sources */,
 				496F8FBC203EEBD4003AB29B /* RouteParametersCodable.swift in Sources */,
 				496F8F49203EEB0F003AB29B /* String+Extensions.swift in Sources */,
 				49F6824220D2C07100B02318 /* ActivityMetadataBuilder.swift in Sources */,
@@ -2625,6 +2669,7 @@
 				496F8F7D203EEBB3003AB29B /* LoggerLevel.swift in Sources */,
 				49FC460920A4793800679F97 /* FocusFeature.swift in Sources */,
 				496F8FF9203EEBDB003AB29B /* FlintFeatures.swift in Sources */,
+				495CBD9B223D6E2100233816 /* SubscriptionProduct.swift in Sources */,
 				49935BF2206D250400CB2B5D /* TimeOrderedResultsController.swift in Sources */,
 				49F6823D20D2BEF100B02318 /* ActivityMetadata.swift in Sources */,
 				4932675F2142FA4D00CC88CB /* Data+Serialization.swift in Sources */,
@@ -2760,6 +2805,7 @@
 				4998079F213419ED00DACFAA /* ActionPerformError.swift in Sources */,
 				49819EBC1FC9C3660013AF55 /* ActionRequest.swift in Sources */,
 				49EFE2BC20C3F4DA00063E5F /* SpeechRecognitionPermissionAdapter.swift in Sources */,
+				495CBD8A223D6E1E00233816 /* NonConsumableProduct.swift in Sources */,
 				49839CE92046D1CA00C0AED3 /* DebugReportable.swift in Sources */,
 				49DFB7D920A3462600D3AE68 /* FeaturePurchaseRequirements.swift in Sources */,
 				49891EB22094BEB600B9BCBF /* PurchaseTrackerObserver.swift in Sources */,
@@ -2773,6 +2819,7 @@
 				493572D41FC9D284003AD465 /* FeatureGroup.swift in Sources */,
 				491211C02158FEA300B199C4 /* IntentShortcutDonationFeature.swift in Sources */,
 				49C9C37A1FFD317800E4D500 /* TopicPath+Extensions.swift in Sources */,
+				495CBD8B223D6E1E00233816 /* ConsumableProduct.swift in Sources */,
 				498F97642077824200209633 /* FocusSelection.swift in Sources */,
 				494F59102098AA140075E7EE /* OperatingSystemVersion+Utilities.swift in Sources */,
 				49E1A231203C31C900F7555C /* FlintInternal.swift in Sources */,
@@ -2781,10 +2828,13 @@
 				49A999FA1FF7FA6700A64E8C /* AnalyticsReporting.swift in Sources */,
 				4976923B201F3CBE00F97BD5 /* URLMappingsBuilder.swift in Sources */,
 				49F6823F20D2C07100B02318 /* ActivityMetadataBuilder.swift in Sources */,
+				495CBD8E223D6E1E00233816 /* NonRenewingSubscriptionProduct.swift in Sources */,
 				493267482142F7F200CC88CB /* FileManager+ZIP.swift in Sources */,
+				495CBD8D223D6E1E00233816 /* AutoRenewingSubscriptionProduct.swift in Sources */,
 				496136C5209900E200291885 /* CameraPermissionAdapter.swift in Sources */,
 				49CF4D3920F5281C0009FFF4 /* FlintLoggable.swift in Sources */,
 				495FD9FE200363290007A427 /* FeaturePath.swift in Sources */,
+				495CBD8C223D6E1E00233816 /* SubscriptionProduct.swift in Sources */,
 				49647D372037434B005F9825 /* StoreKitPurchaseTracker.swift in Sources */,
 				49BC1C5720867C2400A7FC77 /* ActionStack.swift in Sources */,
 				491A348721E7E63600E81D58 /* DonateShortcutIntentAction.swift in Sources */,

--- a/FlintCore.xcodeproj/project.pbxproj
+++ b/FlintCore.xcodeproj/project.pbxproj
@@ -669,6 +669,10 @@
 		49B4DCC020F512D5006A6241 /* NSUserActivity+FlintAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B4DCBE20F512D5006A6241 /* NSUserActivity+FlintAdditions.swift */; };
 		49B4DCC120F512D5006A6241 /* NSUserActivity+FlintAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B4DCBE20F512D5006A6241 /* NSUserActivity+FlintAdditions.swift */; };
 		49B4DCC220F512D5006A6241 /* NSUserActivity+FlintAdditions.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B4DCBE20F512D5006A6241 /* NSUserActivity+FlintAdditions.swift */; };
+		49B6F1C322426FFD0003C847 /* NoQuantityProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B6F1C222426FFD0003C847 /* NoQuantityProduct.swift */; };
+		49B6F1C422426FFD0003C847 /* NoQuantityProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B6F1C222426FFD0003C847 /* NoQuantityProduct.swift */; };
+		49B6F1C522426FFD0003C847 /* NoQuantityProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B6F1C222426FFD0003C847 /* NoQuantityProduct.swift */; };
+		49B6F1C622426FFD0003C847 /* NoQuantityProduct.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49B6F1C222426FFD0003C847 /* NoQuantityProduct.swift */; };
 		49BC1C4520795E9E00A7FC77 /* LIFOArrayQueueDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49BC1C4420795E9E00A7FC77 /* LIFOArrayQueueDataSource.swift */; };
 		49BC1C4620795E9E00A7FC77 /* LIFOArrayQueueDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49BC1C4420795E9E00A7FC77 /* LIFOArrayQueueDataSource.swift */; };
 		49BC1C4720795E9E00A7FC77 /* LIFOArrayQueueDataSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49BC1C4420795E9E00A7FC77 /* LIFOArrayQueueDataSource.swift */; };
@@ -1072,6 +1076,7 @@
 		49B06F1820A4C5AC004564E1 /* FlintCore_watchOSTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlintCore_watchOSTests.swift; sourceTree = "<group>"; };
 		49B06F1A20A4C5AC004564E1 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		49B4DCBE20F512D5006A6241 /* NSUserActivity+FlintAdditions.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "NSUserActivity+FlintAdditions.swift"; sourceTree = "<group>"; };
+		49B6F1C222426FFD0003C847 /* NoQuantityProduct.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoQuantityProduct.swift; sourceTree = "<group>"; };
 		49BC1C4420795E9E00A7FC77 /* LIFOArrayQueueDataSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LIFOArrayQueueDataSource.swift; sourceTree = "<group>"; };
 		49BC1C4920795EB800A7FC77 /* UniquelyIdentifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UniquelyIdentifiable.swift; sourceTree = "<group>"; };
 		49BC1C5620867C2400A7FC77 /* ActionStack.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ActionStack.swift; sourceTree = "<group>"; };
@@ -1731,6 +1736,7 @@
 				495CBD86223D6C1F00233816 /* SubscriptionProduct.swift */,
 				495CBD87223D6C2100233816 /* AutoRenewingSubscriptionProduct.swift */,
 				495CBD89223D6C2600233816 /* NonRenewingSubscriptionProduct.swift */,
+				49B6F1C222426FFD0003C847 /* NoQuantityProduct.swift */,
 				49966D92200A644A004C4AA0 /* PurchaseTracker.swift */,
 				49891EB12094BEB600B9BCBF /* PurchaseTrackerObserver.swift */,
 				49DB92422073C67900F758DC /* PurchaseRequirement.swift */,
@@ -2186,6 +2192,7 @@
 				496F8F58203EEBB1003AB29B /* ContextualLoggerFactory.swift in Sources */,
 				49839CEA2046D1CA00C0AED3 /* DebugReportable.swift in Sources */,
 				496F8FC9203EEBDA003AB29B /* FeatureDefinition.swift in Sources */,
+				49B6F1C422426FFD0003C847 /* NoQuantityProduct.swift in Sources */,
 				499FE35920BD8C3A00552CE9 /* FeatureConstraintStatus.swift in Sources */,
 				492B2A4420FE9A2400F4EAB0 /* CompletionRequirement.swift in Sources */,
 				49DFB7DF20A3464800D3AE68 /* FeaturePermissionRequirements.swift in Sources */,
@@ -2401,6 +2408,7 @@
 				49839CEB2046D1CA00C0AED3 /* DebugReportable.swift in Sources */,
 				496F8FDE203EEBDA003AB29B /* FeatureDefinition.swift in Sources */,
 				499FE35A20BD8C3A00552CE9 /* FeatureConstraintStatus.swift in Sources */,
+				49B6F1C522426FFD0003C847 /* NoQuantityProduct.swift in Sources */,
 				492B2A4520FE9A2500F4EAB0 /* CompletionRequirement.swift in Sources */,
 				49DFB7E020A3464800D3AE68 /* FeaturePermissionRequirements.swift in Sources */,
 				4956D5DB209895C2002A2A35 /* UserFeatureTogglesObserver.swift in Sources */,
@@ -2567,6 +2575,7 @@
 				496F8FFD203EEBDB003AB29B /* Feature.swift in Sources */,
 				496F8FBB203EEBD4003AB29B /* LinkCreator.swift in Sources */,
 				496F9000203EEBDB003AB29B /* FlintInternal.swift in Sources */,
+				49B6F1C622426FFD0003C847 /* NoQuantityProduct.swift in Sources */,
 				499FE34520BD892900552CE9 /* DefaultFeatureConstraintEvaluationResults.swift in Sources */,
 				49EA0BD1208B874900B9A32E /* SmartDispatchQueue.swift in Sources */,
 				49F37A49209B2C2200B27671 /* FeatureConstraintsEvaluation.swift in Sources */,
@@ -2822,6 +2831,7 @@
 				495CBD8B223D6E1E00233816 /* ConsumableProduct.swift in Sources */,
 				498F97642077824200209633 /* FocusSelection.swift in Sources */,
 				494F59102098AA140075E7EE /* OperatingSystemVersion+Utilities.swift in Sources */,
+				49B6F1C322426FFD0003C847 /* NoQuantityProduct.swift in Sources */,
 				49E1A231203C31C900F7555C /* FlintInternal.swift in Sources */,
 				49F2CF241FF7EB2C004F16EF /* ConditionalActionBinding.swift in Sources */,
 				4980005620B3621200D68321 /* URLExecutionContext.swift in Sources */,

--- a/FlintCore/Constraints/FeatureConstraintsBuilder+Extensions.swift
+++ b/FlintCore/Constraints/FeatureConstraintsBuilder+Extensions.swift
@@ -25,15 +25,23 @@ public extension FeatureConstraintsBuilder {
     }
 
     /// Call to declare a product that your feature requires
-    public func purchase(_ product: Product) {
+    public func purchase(_ product: NonConsumableProduct) {
         purchase(PurchaseRequirement(product))
     }
 
-    /// Call to declare a list of products that your feature requires
-    public func purchases(_ products: Product...) {
-        for product in products {
-            purchase(PurchaseRequirement(product))
-        }
+    /// Call to declare a product that your feature requires
+    public func purchase(_ product: ConsumableProduct, quantity: UInt) {
+        purchase(PurchaseRequirement(product, quantity: quantity))
+    }
+
+    /// Call to declare a product that your feature requires
+    public func purchase(_ product: SubscriptionProduct) {
+        purchase(PurchaseRequirement(product))
+    }
+
+    /// Call to declare a list of products that your feature requires. All must be purchased for the constraint to be met
+    public func purchases(_ products: NonConsumableProduct...) {
+        purchase(PurchaseRequirement(products: Set(products), matchingCriteria: .all))
     }
 }
 

--- a/FlintCore/Constraints/FeatureConstraintsBuilder+Extensions.swift
+++ b/FlintCore/Constraints/FeatureConstraintsBuilder+Extensions.swift
@@ -24,6 +24,26 @@ public extension FeatureConstraintsBuilder {
         }
     }
 
+    /// Convenience function for use when constructing constraints in the constraints builder, where
+    /// any of the listed requirements will fulfil the requirement. Used for mixing non-consumable and consumable requirements:
+    ///
+    /// ```
+    /// requirements.purchase(anyOf: .init(nonConsumableProduct), .init(creditsProduct, quantity: 5))
+    /// ```
+    public func purchase(anyOf requirements: PurchaseRequirement...) {
+        purchase(PurchaseRequirement(products: [], quantity: nil, matchingCriteria: .any, dependencies:requirements))
+    }
+    
+    /// Convenience function for use when constructing constraints in the constraints builder, where
+    /// all of the listed requirements must be fulfilled to fulfil the requirement. Used for mixing non-consumable and consumable requirements:
+    ///
+    /// ```
+    /// requirements.purchase(allOf: .init(nonConsumableProduct), .init(creditsProduct, quantity: 5))
+    /// ```
+    public func purchase(allOf requirements: PurchaseRequirement...) {
+        purchase(PurchaseRequirement(products: [], quantity: nil, matchingCriteria: .all, dependencies:requirements))
+    }
+    
     /// Call to declare a product that your feature requires
     public func purchase(_ product: NonConsumableProduct) {
         purchase(PurchaseRequirement(product))
@@ -43,6 +63,31 @@ public extension FeatureConstraintsBuilder {
     public func purchases(_ products: NonConsumableProduct...) {
         purchase(PurchaseRequirement(products: Set(products), matchingCriteria: .all))
     }
+
+    /// Convenience function for use when constructing constraints in the constraints builder, where
+    /// any of the listed purchases will fulfil the requirement
+    public func purchase(anyOf products: Set<NoQuantityProduct>) {
+        purchase(PurchaseRequirement(products: products, quantity: nil, matchingCriteria: .any))
+    }
+    
+    /// Convenience function for use when constructing constraints in the constraints builder, where
+    /// any of the listed purchases will fulfil the requirement
+    public func purchase(anyOf products: NoQuantityProduct...) {
+        purchase(PurchaseRequirement(products: Set(products), quantity: nil, matchingCriteria: .any))
+    }
+    
+    /// Convenience function for use when constructing constraints in the constraints builder, where
+    /// all of the listed purchases will fulfil the requirement
+    public func purchase(allOf products: NoQuantityProduct...) {
+        purchase(PurchaseRequirement(products: Set(products), quantity: nil, matchingCriteria: .all))
+    }
+    
+    /// Convenience function for use when constructing constraints in the constraints builder, where
+    /// all of the listed purchases will fulfil the requirement
+    public func purchase(allOf products: Set<NoQuantityProduct>) {
+        purchase(PurchaseRequirement(products: products, quantity: nil, matchingCriteria: .all))
+    }
+    
 }
 
 /// Platform versions

--- a/FlintCore/Constraints/Preconditions/PurchasePreconditionEvaluator.swift
+++ b/FlintCore/Constraints/Preconditions/PurchasePreconditionEvaluator.swift
@@ -21,7 +21,7 @@ public class PurchasePreconditionEvaluator: FeaturePreconditionConstraintEvaluat
             flintBug("Incorrect precondition type '\(precondition)' passed to purchase evaluator")
         }
 
-        return requirement.isFulfilled(validator: purchaseTracker)
+        return requirement.isFulfilled(purchaseTracker: purchaseTracker, feature: feature)
     }
 }
 

--- a/FlintCore/Core/Flint.swift
+++ b/FlintCore/Core/Flint.swift
@@ -476,7 +476,9 @@ extension Flint {
             permissionChecker = DefaultPermissionChecker()
         }
         
-        constraintsEvaluator = DefaultFeatureConstraintsEvaluator(permissionChecker: _permissionChecker, purchaseTracker: purchaseTracker, userToggles: userFeatureToggles)
+        constraintsEvaluator = DefaultFeatureConstraintsEvaluator(permissionChecker: _permissionChecker,
+                                                                  purchaseTracker: purchaseTracker,
+                                                                  userToggles: userFeatureToggles)
         
         if availabilityChecker == nil {
             availabilityChecker = DefaultAvailabilityChecker(constraintsEvaluator: _constraintsEvaluator)

--- a/FlintCore/Purchases/AutoRenewingSubscriptionProduct.swift
+++ b/FlintCore/Purchases/AutoRenewingSubscriptionProduct.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-/// A marker protocol for products that represent auto-renewing subscriptions
+/// A base type for products that represent auto-renewing subscriptions
 open class AutoRenewingSubscriptionProduct: SubscriptionProduct {
     public override init(name: String, description: String? = nil, productID: String) {
         super.init(name: name, description: description, productID: productID)

--- a/FlintCore/Purchases/AutoRenewingSubscriptionProduct.swift
+++ b/FlintCore/Purchases/AutoRenewingSubscriptionProduct.swift
@@ -1,0 +1,16 @@
+//
+//  AutoRenewingSubscriptionProduct.swift
+//  FlintCore
+//
+//  Created by Marc Palmer on 16/03/2019.
+//  Copyright © 2019 Montana Floss Co. Ltd. All rights reserved.
+//
+
+import Foundation
+
+/// A marker protocol for products that represent auto-renewing subscriptions
+open class AutoRenewingSubscriptionProduct: SubscriptionProduct {
+    public override init(name: String, description: String? = nil, productID: String) {
+        super.init(name: name, description: description, productID: productID)
+    }
+}

--- a/FlintCore/Purchases/ConsumableProduct.swift
+++ b/FlintCore/Purchases/ConsumableProduct.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-/// A marker protocol for products that represent consumables
+/// A base product type for products that represent consumables such as credits
 open class ConsumableProduct: Product {
     public override init(name: String, description: String? = nil, productID: String) {
         super.init(name: name, description: description, productID: productID)

--- a/FlintCore/Purchases/ConsumableProduct.swift
+++ b/FlintCore/Purchases/ConsumableProduct.swift
@@ -1,0 +1,16 @@
+//
+//  ConsumableProduct.swift
+//  FlintCore
+//
+//  Created by Marc Palmer on 16/03/2019.
+//  Copyright © 2019 Montana Floss Co. Ltd. All rights reserved.
+//
+
+import Foundation
+
+/// A marker protocol for products that represent consumables
+open class ConsumableProduct: Product {
+    public override init(name: String, description: String? = nil, productID: String) {
+        super.init(name: name, description: description, productID: productID)
+    }
+}

--- a/FlintCore/Purchases/NoQuantityProduct.swift
+++ b/FlintCore/Purchases/NoQuantityProduct.swift
@@ -1,0 +1,13 @@
+//
+//  NoQuantityProduct.swift
+//  FlintCore
+//
+//  Created by Marc Palmer on 20/03/2019.
+//  Copyright © 2019 Montana Floss Co. Ltd. All rights reserved.
+//
+
+import Foundation
+
+/// A base class for purchaseable products that do not have a quantity.
+open class NoQuantityProduct: Product {
+}

--- a/FlintCore/Purchases/NonConsumableProduct.swift
+++ b/FlintCore/Purchases/NonConsumableProduct.swift
@@ -1,0 +1,16 @@
+//
+//  NonConsumableProduct.swift
+//  FlintCore
+//
+//  Created by Marc Palmer on 16/03/2019.
+//  Copyright © 2019 Montana Floss Co. Ltd. All rights reserved.
+//
+
+import Foundation
+
+/// A marker protocol for products that represent consumables
+open class NonConsumableProduct: Product {
+    public override init(name: String, description: String? = nil, productID: String) {
+        super.init(name: name, description: description, productID: productID)
+    }
+}

--- a/FlintCore/Purchases/NonConsumableProduct.swift
+++ b/FlintCore/Purchases/NonConsumableProduct.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// A marker protocol for products that represent consumables
-open class NonConsumableProduct: Product {
+open class NonConsumableProduct: NoQuantityProduct {
     public override init(name: String, description: String? = nil, productID: String) {
         super.init(name: name, description: description, productID: productID)
     }

--- a/FlintCore/Purchases/NonRenewingSubscriptionProduct.swift
+++ b/FlintCore/Purchases/NonRenewingSubscriptionProduct.swift
@@ -1,0 +1,16 @@
+//
+//  NonRenewingSubscriptionProduct.swift
+//  FlintCore
+//
+//  Created by Marc Palmer on 16/03/2019.
+//  Copyright © 2019 Montana Floss Co. Ltd. All rights reserved.
+//
+
+import Foundation
+
+/// A marker protocol for products that represent non-renewing subscriptions
+open class NonRenewingSubscriptionProduct: SubscriptionProduct {
+    public override init(name: String, description: String? = nil, productID: String) {
+        super.init(name: name, description: description, productID: productID)
+    }
+}

--- a/FlintCore/Purchases/NonRenewingSubscriptionProduct.swift
+++ b/FlintCore/Purchases/NonRenewingSubscriptionProduct.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-/// A marker protocol for products that represent non-renewing subscriptions
+/// A base type for products that represent non-renewing subscriptions
 open class NonRenewingSubscriptionProduct: SubscriptionProduct {
     public override init(name: String, description: String? = nil, productID: String) {
         super.init(name: name, description: description, productID: productID)

--- a/FlintCore/Purchases/Product.swift
+++ b/FlintCore/Purchases/Product.swift
@@ -42,7 +42,7 @@ open class Product: Hashable, Equatable {
     /// purchase.
     public let productID: String
     
-    fileprivate init(name: String, description: String? = nil, productID: String) {
+    init(name: String, description: String? = nil, productID: String) {
         self.name = name
         self.description = description
         self.productID = productID
@@ -54,40 +54,5 @@ open class Product: Hashable, Equatable {
     
     public static func ==(lhs: Product, rhs: Product) -> Bool {
         return lhs.productID == rhs.productID
-    }
-}
-
-/// A marker protocol for products that represent consumables
-open class NonConsumableProduct: Product {
-    override init(name: String, description: String? = nil, productID: String) {
-        super.init(name: name, description: description, productID: productID)
-    }
-}
-
-/// A marker protocol for products that represent consumables
-open class ConsumableProduct: Product {
-    override init(name: String, description: String? = nil, productID: String) {
-        super.init(name: name, description: description, productID: productID)
-    }
-}
-
-/// A marker protocol for products that represent auto-renewing subscriptions
-open class SubscriptionProduct: Product {
-    override init(name: String, description: String? = nil, productID: String) {
-        super.init(name: name, description: description, productID: productID)
-    }
-}
-
-/// A marker protocol for products that represent auto-renewing subscriptions
-open class AutoRenewingSubscriptionProduct: SubscriptionProduct {
-    override init(name: String, description: String? = nil, productID: String) {
-        super.init(name: name, description: description, productID: productID)
-    }
-}
-
-/// A marker protocol for products that represent non-renewing subscriptions
-open class NonRenewingSubscriptionProduct: SubscriptionProduct {
-    override init(name: String, description: String? = nil, productID: String) {
-        super.init(name: name, description: description, productID: productID)
     }
 }

--- a/FlintCore/Purchases/Product.swift
+++ b/FlintCore/Purchases/Product.swift
@@ -56,7 +56,3 @@ open class Product: Hashable, Equatable {
         return lhs.productID == rhs.productID
     }
 }
-
-open class NoQuantityProduct: Product {
-}
-

--- a/FlintCore/Purchases/Product.swift
+++ b/FlintCore/Purchases/Product.swift
@@ -41,11 +41,22 @@ open class Product: Hashable, Equatable {
     /// For Apple App Store / StoreKit you'll need to use the Product ID you specified when creating the in-app
     /// purchase.
     public let productID: String
+
+    /// Return the `Product` instance associated with the product ID.
+    public static func productByID(_ id: String) -> Product? {
+        return allProducts.first { $0.productID == id }
+    }
+    
+    private static var allProducts = [Product]()
     
     init(name: String, description: String? = nil, productID: String) {
         self.name = name
         self.description = description
         self.productID = productID
+        guard Product.productByID(productID) == nil else {
+            flintUsageError("Product ID '\(productID)' has been used in multiple products including: \(self)")
+        }
+        Product.allProducts.append(self)
     }
     
     public var hashValue: Int {

--- a/FlintCore/Purchases/Product.swift
+++ b/FlintCore/Purchases/Product.swift
@@ -25,7 +25,7 @@ import Foundation
 ///
 /// - note: We use class semantics here so that the app can subclass it to include additional properties as required
 /// for the purchasing mechanism they use.
-public class Product: Hashable, Equatable {
+open class Product: Hashable, Equatable {
     
     /// The name of the product, for display to the user and debugging. e.g. "Premium Subscription".
     /// To localise, you'll want to use a value that is a key you can resolve against a strings bundle.
@@ -53,4 +53,20 @@ public class Product: Hashable, Equatable {
     public static func ==(lhs: Product, rhs: Product) -> Bool {
         return lhs.productID == rhs.productID
     }
+}
+
+/// A marker protocol for products that represent consumables
+open class NonConsumableProduct: Product {
+}
+
+/// A marker protocol for products that represent consumables
+open class ConsumableProduct: Product {
+}
+
+/// A marker protocol for products that represent auto-renewing subscriptions
+open class AutoRenewingSubscriptionProduct: Product {
+}
+
+/// A marker protocol for products that represent non-renewing subscriptions
+open class NonRenewingSubscriptionProduct: Product {
 }

--- a/FlintCore/Purchases/Product.swift
+++ b/FlintCore/Purchases/Product.swift
@@ -56,3 +56,7 @@ open class Product: Hashable, Equatable {
         return lhs.productID == rhs.productID
     }
 }
+
+open class NoQuantityProduct: Product {
+}
+

--- a/FlintCore/Purchases/Product.swift
+++ b/FlintCore/Purchases/Product.swift
@@ -28,11 +28,13 @@ import Foundation
 open class Product: Hashable, Equatable {
     
     /// The name of the product, for display to the user and debugging. e.g. "Premium Subscription".
-    /// To localise, you'll want to use a value that is a key you can resolve against a strings bundle.
+    /// To localise, you'll want to use a value that is a key you can resolve against a strings bundle,
+    /// or for StoreKit use the SKProduct `localizedName`
     public let name: String
 
     /// The description of the product, for display primaroily in debugging UIs.
-    /// If you want to also show this to users and localise, you'll want to use a value that is a key you can resolve against a strings bundle.
+    /// If you want to also show this to users and localise, you'll want to use a value that is a key you can resolve
+    /// against a strings bundle, or for StoreKit use the SKProduct `localizedDescription`
     public let description: String?
     
     /// A product ID used by your purchase subsystem to uniquely identify the product that to be purchased.
@@ -40,7 +42,7 @@ open class Product: Hashable, Equatable {
     /// purchase.
     public let productID: String
     
-    public init(name: String, description: String? = nil, productID: String) {
+    fileprivate init(name: String, description: String? = nil, productID: String) {
         self.name = name
         self.description = description
         self.productID = productID
@@ -57,16 +59,35 @@ open class Product: Hashable, Equatable {
 
 /// A marker protocol for products that represent consumables
 open class NonConsumableProduct: Product {
+    override init(name: String, description: String? = nil, productID: String) {
+        super.init(name: name, description: description, productID: productID)
+    }
 }
 
 /// A marker protocol for products that represent consumables
 open class ConsumableProduct: Product {
+    override init(name: String, description: String? = nil, productID: String) {
+        super.init(name: name, description: description, productID: productID)
+    }
 }
 
 /// A marker protocol for products that represent auto-renewing subscriptions
-open class AutoRenewingSubscriptionProduct: Product {
+open class SubscriptionProduct: Product {
+    override init(name: String, description: String? = nil, productID: String) {
+        super.init(name: name, description: description, productID: productID)
+    }
+}
+
+/// A marker protocol for products that represent auto-renewing subscriptions
+open class AutoRenewingSubscriptionProduct: SubscriptionProduct {
+    override init(name: String, description: String? = nil, productID: String) {
+        super.init(name: name, description: description, productID: productID)
+    }
 }
 
 /// A marker protocol for products that represent non-renewing subscriptions
-open class NonRenewingSubscriptionProduct: Product {
+open class NonRenewingSubscriptionProduct: SubscriptionProduct {
+    override init(name: String, description: String? = nil, productID: String) {
+        super.init(name: name, description: description, productID: productID)
+    }
 }

--- a/FlintCore/Purchases/PurchaseRequirement.swift
+++ b/FlintCore/Purchases/PurchaseRequirement.swift
@@ -56,14 +56,14 @@ public class PurchaseRequirement: Hashable, Equatable, CustomStringConvertible {
     
     /// Convenience function for use when constructing constraints in the constraints builder, where
     /// any of the listed purchases will fulfil the requirement
-    public static func anyOf(products: Set<NoQuantityProduct>, dependencies: [PurchaseRequirement]? = nil) -> PurchaseRequirement {
-        return PurchaseRequirement(products: products, quantity: nil, matchingCriteria: .any, dependencies: dependencies)
+    public static func anyOf(_ products: Set<NoQuantityProduct>) -> PurchaseRequirement {
+        return PurchaseRequirement(products: products, quantity: nil, matchingCriteria: .any)
     }
     
     /// Convenience function for use when constructing constraints in the constraints builder, where
     /// all of the listed purchases will fulfil the requirement
-    public static func allOf(products: Set<NoQuantityProduct>, dependencies: [PurchaseRequirement]? = nil) -> PurchaseRequirement {
-        return PurchaseRequirement(products: products, quantity: nil, matchingCriteria: .all, dependencies: dependencies)
+    public static func allOf(_ products: Set<NoQuantityProduct>) -> PurchaseRequirement {
+        return PurchaseRequirement(products: products, quantity: nil, matchingCriteria: .all)
     }
     
     /// Initialise the requirement with its products, matching criteria and dependencies.

--- a/FlintCore/Purchases/PurchaseRequirement.swift
+++ b/FlintCore/Purchases/PurchaseRequirement.swift
@@ -67,7 +67,9 @@ public class PurchaseRequirement: Hashable, Equatable, CustomStringConvertible {
             case .any:
                 var result: Bool?
                 for product in products {
-                    result = validator.isPurchased(product.productID)
+                    if let nonConsumableProduct = product as? NonConsumableProduct {
+                        result = validator.isPurchased(nonConsumableProduct)
+                    }
                     if result == true {
                         break
                     }
@@ -76,7 +78,9 @@ public class PurchaseRequirement: Hashable, Equatable, CustomStringConvertible {
             case .all:
                 var result: Bool?
                 for product in products {
-                    result = validator.isPurchased(product.productID)
+                    if let nonConsumableProduct = product as? NonConsumableProduct {
+                        result = validator.isPurchased(nonConsumableProduct)
+                    }
                     if !(result == true) {
                         break
                     }

--- a/FlintCore/Purchases/PurchaseRequirement.swift
+++ b/FlintCore/Purchases/PurchaseRequirement.swift
@@ -54,8 +54,20 @@ public class PurchaseRequirement: Hashable, Equatable, CustomStringConvertible {
     /// when you need to show a store UI to unlock the feature.
     public let quantity: UInt?
     
+    /// Convenience function for use when constructing constraints in the constraints builder, where
+    /// any of the listed purchases will fulfil the requirement
+    public static func anyOf(products: Set<NoQuantityProduct>, dependencies: [PurchaseRequirement]? = nil) -> PurchaseRequirement {
+        return PurchaseRequirement(products: products, quantity: nil, matchingCriteria: .any, dependencies: dependencies)
+    }
+    
+    /// Convenience function for use when constructing constraints in the constraints builder, where
+    /// all of the listed purchases will fulfil the requirement
+    public static func allOf(products: Set<NoQuantityProduct>, dependencies: [PurchaseRequirement]? = nil) -> PurchaseRequirement {
+        return PurchaseRequirement(products: products, quantity: nil, matchingCriteria: .all, dependencies: dependencies)
+    }
+    
     /// Initialise the requirement with its products, matching criteria and dependencies.
-    private init(products: Set<Product>, quantity: UInt?, matchingCriteria: Criteria, dependencies: [PurchaseRequirement]? = nil) {
+    init(products: Set<Product>, quantity: UInt?, matchingCriteria: Criteria, dependencies: [PurchaseRequirement]? = nil) {
         self.products = products
         self.quantity = quantity
         self.matchingCriteria = matchingCriteria

--- a/FlintCore/Purchases/PurchaseRequirement.swift
+++ b/FlintCore/Purchases/PurchaseRequirement.swift
@@ -61,6 +61,18 @@ public class PurchaseRequirement: Hashable, Equatable, CustomStringConvertible {
     }
     
     /// Convenience function for use when constructing constraints in the constraints builder, where
+    /// any of the listed purchases will fulfil the requirement
+    public static func anyOf(_ products: NoQuantityProduct...) -> PurchaseRequirement {
+        return PurchaseRequirement(products: Set(products), quantity: nil, matchingCriteria: .any)
+    }
+    
+    /// Convenience function for use when constructing constraints in the constraints builder, where
+    /// all of the listed purchases will fulfil the requirement
+    public static func allOf(_ products: NoQuantityProduct...) -> PurchaseRequirement {
+        return PurchaseRequirement(products: Set(products), quantity: nil, matchingCriteria: .all)
+    }
+    
+    /// Convenience function for use when constructing constraints in the constraints builder, where
     /// all of the listed purchases will fulfil the requirement
     public static func allOf(_ products: Set<NoQuantityProduct>) -> PurchaseRequirement {
         return PurchaseRequirement(products: products, quantity: nil, matchingCriteria: .all)

--- a/FlintCore/Purchases/PurchaseRequirement.swift
+++ b/FlintCore/Purchases/PurchaseRequirement.swift
@@ -54,30 +54,6 @@ public class PurchaseRequirement: Hashable, Equatable, CustomStringConvertible {
     /// when you need to show a store UI to unlock the feature.
     public let quantity: UInt?
     
-    /// Convenience function for use when constructing constraints in the constraints builder, where
-    /// any of the listed purchases will fulfil the requirement
-    public static func anyOf(_ products: Set<NoQuantityProduct>) -> PurchaseRequirement {
-        return PurchaseRequirement(products: products, quantity: nil, matchingCriteria: .any)
-    }
-    
-    /// Convenience function for use when constructing constraints in the constraints builder, where
-    /// any of the listed purchases will fulfil the requirement
-    public static func anyOf(_ products: NoQuantityProduct...) -> PurchaseRequirement {
-        return PurchaseRequirement(products: Set(products), quantity: nil, matchingCriteria: .any)
-    }
-    
-    /// Convenience function for use when constructing constraints in the constraints builder, where
-    /// all of the listed purchases will fulfil the requirement
-    public static func allOf(_ products: NoQuantityProduct...) -> PurchaseRequirement {
-        return PurchaseRequirement(products: Set(products), quantity: nil, matchingCriteria: .all)
-    }
-    
-    /// Convenience function for use when constructing constraints in the constraints builder, where
-    /// all of the listed purchases will fulfil the requirement
-    public static func allOf(_ products: Set<NoQuantityProduct>) -> PurchaseRequirement {
-        return PurchaseRequirement(products: products, quantity: nil, matchingCriteria: .all)
-    }
-    
     /// Initialise the requirement with its products, matching criteria and dependencies.
     init(products: Set<Product>, quantity: UInt?, matchingCriteria: Criteria, dependencies: [PurchaseRequirement]? = nil) {
         self.products = products
@@ -128,7 +104,8 @@ public class PurchaseRequirement: Hashable, Equatable, CustomStringConvertible {
                 matched = result
         }
         
-        if matched == true {
+        // Only evaluate dependencies if this level's requirements are met, or there are no direct requirements at this level
+        if matched == true || products.count == 0 {
             guard let dependencies = dependencies else {
                 return matched
             }

--- a/FlintCore/Purchases/PurchaseTracker.swift
+++ b/FlintCore/Purchases/PurchaseTracker.swift
@@ -23,7 +23,22 @@ public protocol PurchaseTracker {
     func removeObserver(_ observer: PurchaseTrackerObserver)
 
     /// Return whether or not the specified product ID has been paid for (and hence features requiring it can be enabled)
-    /// by the user. If the status is not yet known, the implementation can return `nil` to indicate this indeterminate status.
-    /// - note: Consumables subscriptions will not be pass to this function
+    /// by the user.
+    /// - note: If the status is not yet known, the implementation can return `nil` to indicate this indeterminate status.
     func isPurchased(_ product: NonConsumableProduct) -> Bool?
+    
+    /// Return whether or not there is an active subscription for this product, whether it is auto-renewing or not.
+    /// - note: If the status is not yet known, the implementation can return `nil` to indicate this indeterminate status.
+    func isSubscriptionActive(_ product: SubscriptionProduct) -> Bool?
+
+    /// Return whether or not past purchases, perhaps consumable credits, mean that this feature is currently enabled.
+    ///
+    /// This is your application's opportunity to implement custom purchase management such as allowing purchase of
+    /// specific features with a given number of consumable in-app credits, or a custom cross-device purchase syncing
+    /// mechanism, or "grandfathering" users in to new features because they bought the app outright in the past.
+    ///
+    /// - note: If the status is false, the result of prior calls to `isPurchased` and `isSubscriptionActive` will take precendent
+    /// if appropriate. If this function returns `true`, the feature will always be enabled if all its other constraints
+    /// are met.
+    func isFeatureEnabledByPastPurchases(_ feature: FeatureDefinition.Type) -> Bool
 }

--- a/FlintCore/Purchases/PurchaseTracker.swift
+++ b/FlintCore/Purchases/PurchaseTracker.swift
@@ -22,7 +22,8 @@ public protocol PurchaseTracker {
     /// Call to remove an observer for changes to purchases
     func removeObserver(_ observer: PurchaseTrackerObserver)
 
-    /// Return whether or not the specified product ID has been paid for (or should be enabled) by the user.
-    /// If the status is not yet known, the implementation can return `nil` to indicate this indeterminate status.
-    func isPurchased(_ productID: String) -> Bool?
+    /// Return whether or not the specified product ID has been paid for (and hence features requiring it can be enabled)
+    /// by the user. If the status is not yet known, the implementation can return `nil` to indicate this indeterminate status.
+    /// - note: Consumables subscriptions will not be pass to this function
+    func isPurchased(_ product: NonConsumableProduct) -> Bool?
 }

--- a/FlintCore/Purchases/PurchaseTracker.swift
+++ b/FlintCore/Purchases/PurchaseTracker.swift
@@ -1,5 +1,5 @@
 //
-//  PurchaseValidator.swift
+//  PurchaseTracker.swift
 //  FlintCore
 //
 //  Created by Marc Palmer on 13/01/2018.

--- a/FlintCore/Purchases/StoreKit-Specific/StoreKitPurchaseTracker.swift
+++ b/FlintCore/Purchases/StoreKit-Specific/StoreKitPurchaseTracker.swift
@@ -78,8 +78,8 @@ public class StoreKitPurchaseTracker: NSObject, PurchaseTracker {
     }
 
     /// Called to see if a specific product has been purchased
-    public func isPurchased(_ productID: String) -> Bool? {
-        if let productStatus = purchases[productID] {
+    public func isPurchased(_ product: NonConsumableProduct) -> Bool? {
+        if let productStatus = purchases[product.productID] {
             return productStatus.isPurchased
         } else {
             return nil

--- a/FlintCore/Purchases/StoreKit-Specific/StoreKitPurchaseTracker.swift
+++ b/FlintCore/Purchases/StoreKit-Specific/StoreKitPurchaseTracker.swift
@@ -132,7 +132,15 @@ extension StoreKitPurchaseTracker: SKPaymentTransactionObserver {
             logger?.debug("Transaction updated, status: \(transaction.transactionState.rawValue) id: \(transaction.transactionIdentifier != nil ? transaction.transactionIdentifier! : "nil") for payment of product \(transaction.payment.productIdentifier) with quantity \(transaction.payment.quantity)")
             
             let productID = transaction.payment.productIdentifier
-
+            guard let product = Product.productByID(productID) else {
+                logger?.error("Transaction updated for product ID not registered as a Product, will not store the fact this is purchased: \(productID)")
+                continue
+            }
+            guard product is NonConsumableProduct else {
+                logger?.error("Transaction updated for product ID that is not a non-consumable, will not store the fact this is purchased: \(productID)")
+                continue
+            }
+            
             /// !!! TODO: At least salt and hash the product IDs to make it harder to hack?
             switch transaction.transactionState {
                 case .purchased, .restored:

--- a/FlintCore/Purchases/StoreKit-Specific/StoreKitPurchaseTracker.swift
+++ b/FlintCore/Purchases/StoreKit-Specific/StoreKitPurchaseTracker.swift
@@ -86,6 +86,14 @@ public class StoreKitPurchaseTracker: NSObject, PurchaseTracker {
         }
     }
 
+    public func isSubscriptionActive(_ product: SubscriptionProduct) -> Bool? {
+        return nil
+    }
+    
+    public func isFeatureEnabledByPastPurchases(_ feature: FeatureDefinition.Type) -> Bool {
+        return false
+    }
+
     /// Indicate the purchase was successful, and store this fact
     func didPurchase(_ productID: String) throws {
         logger?.debug("Recording purchase of iTunes product ID: \(productID)")

--- a/FlintCore/Purchases/SubscriptionProduct.swift
+++ b/FlintCore/Purchases/SubscriptionProduct.swift
@@ -1,0 +1,16 @@
+//
+//  SubscriptionProduct.swift
+//  FlintCore
+//
+//  Created by Marc Palmer on 16/03/2019.
+//  Copyright © 2019 Montana Floss Co. Ltd. All rights reserved.
+//
+
+import Foundation
+
+/// A marker protocol for products that represent auto-renewing subscriptions
+open class SubscriptionProduct: Product {
+    public override init(name: String, description: String? = nil, productID: String) {
+        super.init(name: name, description: description, productID: productID)
+    }
+}

--- a/FlintCore/Purchases/SubscriptionProduct.swift
+++ b/FlintCore/Purchases/SubscriptionProduct.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// A marker protocol for products that represent auto-renewing subscriptions
-open class SubscriptionProduct: Product {
+open class SubscriptionProduct: NoQuantityProduct {
     public override init(name: String, description: String? = nil, productID: String) {
         super.init(name: name, description: description, productID: productID)
     }

--- a/FlintCore/Purchases/SubscriptionProduct.swift
+++ b/FlintCore/Purchases/SubscriptionProduct.swift
@@ -8,7 +8,7 @@
 
 import Foundation
 
-/// A marker protocol for products that represent auto-renewing subscriptions
+/// A base product type for products that represent any kind of subscription
 open class SubscriptionProduct: NoQuantityProduct {
     public override init(name: String, description: String? = nil, productID: String) {
         super.init(name: name, description: description, productID: productID)

--- a/FlintCoreTests/DefaultAvailabilityCheckerTests.swift
+++ b/FlintCoreTests/DefaultAvailabilityCheckerTests.swift
@@ -212,7 +212,7 @@ final private class ConditionalFeatureA: ConditionalFeature {
     static var description: String = ""
 
     static func constraints(requirements: FeatureConstraintsBuilder) {
-        requirements.purchase(PurchaseRequirement(productA))
+        requirements.purchase(productA)
     }
 
     static func prepare(actions: FeatureActionsBuilder) {
@@ -223,7 +223,7 @@ final private class ConditionalFeatureB: ConditionalFeature {
     static var description: String = ""
     
     static func constraints(requirements: FeatureConstraintsBuilder) {
-        requirements.purchase(PurchaseRequirement(productB))
+        requirements.purchase(productB)
     }
 
     static func prepare(actions: FeatureActionsBuilder) {
@@ -247,7 +247,7 @@ final private class ConditionalFeatureC: ConditionalFeature {
     static var description: String = ""
     
     static func constraints(requirements: FeatureConstraintsBuilder) {
-        requirements.purchase(PurchaseRequirement(productD))
+        requirements.purchase(productD)
     }
     
     static func prepare(actions: FeatureActionsBuilder) {

--- a/FlintCoreTests/DefaultAvailabilityCheckerTests.swift
+++ b/FlintCoreTests/DefaultAvailabilityCheckerTests.swift
@@ -203,10 +203,10 @@ class DefaultAvailabilityCheckerTests: XCTestCase {
 }
 
 
-fileprivate let productA = Product(name: "Product A", description: "This is product A", productID: "PROD-A")
-fileprivate let productB = Product(name: "Product B", description: "This is product B", productID: "PROD-B")
-fileprivate let productC = Product(name: "Product C", description: "This is product C", productID: "PROD-C")
-fileprivate let productD = Product(name: "Product D", description: "This is product D", productID: "PROD-D")
+fileprivate let productA = NonConsumableProduct(name: "Product A", description: "This is product A", productID: "PROD-A")
+fileprivate let productB = NonConsumableProduct(name: "Product B", description: "This is product B", productID: "PROD-B")
+fileprivate let productC = NonConsumableProduct(name: "Product C", description: "This is product C", productID: "PROD-C")
+fileprivate let productD = NonConsumableProduct(name: "Product D", description: "This is product D", productID: "PROD-D")
 
 final private class ConditionalFeatureA: ConditionalFeature {
     static var description: String = ""

--- a/FlintCoreTests/Mocks and Helpers/MockPurchaseValidator.swift
+++ b/FlintCoreTests/Mocks and Helpers/MockPurchaseValidator.swift
@@ -25,12 +25,12 @@ class MockPurchaseValidator: PurchaseTracker {
     
     /// Call this to fake confirmation that a purchase has not been made on this product.
     /// Until the purchase subsystem has checked receipts, the status of such features is unknown.
-    public func confirmNotPurchased(_ product: Product) {
+    public func confirmNotPurchased(_ product: NonConsumableProduct) {
         setPurchased(product, purchased: false)
     }
     
     /// Call this to fake a purchase
-    public func makeFakePurchase(_ product: Product) {
+    public func makeFakePurchase(_ product: NonConsumableProduct) {
         setPurchased(product, purchased: true)
     }
     
@@ -45,7 +45,7 @@ class MockPurchaseValidator: PurchaseTracker {
         }
     }
     
-    private func setPurchased(_ product: Product, purchased: Bool) {
+    private func setPurchased(_ product: NonConsumableProduct, purchased: Bool) {
         fakePurchases[product.productID] = purchased
 
         observers.notifySync { observer in
@@ -53,7 +53,7 @@ class MockPurchaseValidator: PurchaseTracker {
         }
     }
 
-    func isPurchased(_ productID: String) -> Bool? {
-        return fakePurchases[productID]
+    func isPurchased(_ product: NonConsumableProduct) -> Bool? {
+        return fakePurchases[product.productID]
     }
 }

--- a/FlintCoreTests/Mocks and Helpers/MockPurchaseValidator.swift
+++ b/FlintCoreTests/Mocks and Helpers/MockPurchaseValidator.swift
@@ -56,4 +56,12 @@ class MockPurchaseValidator: PurchaseTracker {
     func isPurchased(_ product: NonConsumableProduct) -> Bool? {
         return fakePurchases[product.productID]
     }
+    
+    func isSubscriptionActive(_ product: SubscriptionProduct) -> Bool? {
+        return nil
+    }
+    
+    func isFeatureEnabledByPastPurchases(_ feature: FeatureDefinition.Type) -> Bool {
+        return false
+    }
 }

--- a/FlintUI/iOS/View Controllers/PurchaseBrowserViewController.swift
+++ b/FlintUI/iOS/View Controllers/PurchaseBrowserViewController.swift
@@ -46,7 +46,12 @@ public class PurchaseBrowserViewController: UITableViewController {
             featureMetadata.productsRequired.forEach { allProductsReferenced.insert($0) }
         }
         purchases = allProductsReferenced.map {
-            return ($0, Flint.purchaseTracker?.isPurchased($0.productID))
+            switch $0 {
+                case let nonConsumableProduct as NonConsumableProduct:
+                    return ($0, Flint.purchaseTracker?.isPurchased(nonConsumableProduct))
+                default:
+                    return ($0, nil)
+            }
         }
     }
     
@@ -105,27 +110,63 @@ public class PurchaseBrowserViewController: UITableViewController {
         let alertController = UIAlertController(title: "Purchase status", message: message, preferredStyle: .actionSheet)
         
         if let overrideTracker = debugPurchaseTracker {
-            if debugOverrideStatus != nil {
+            if debugOverrideStatus != nil &&
+                    (entry.product is NonConsumableProduct || entry.product is SubscriptionProduct) {
                 alertController.addAction(UIAlertAction(title: "Remove override", style: .default, handler: { _ in
-                    overrideTracker.invalidatePurchaseOverride(productID: entry.product.productID)
+                    switch entry.product {
+                        case let nonConsumableProduct as NonConsumableProduct:
+                            overrideTracker.invalidatePurchaseOverride(product: nonConsumableProduct)
+                        case let subscriptionProduct as SubscriptionProduct:
+                            overrideTracker.invalidatePurchaseOverride(product: subscriptionProduct)
+                        default:
+                            flintBug("We should not be able to remove overrides on product type: \(entry.product)")
+                            break
+                    }
                     self.refresh()
                 }))
             }
-            if debugOverrideStatus != .purchased {
+            if debugOverrideStatus != .purchased &&
+                    (entry.product is NonConsumableProduct || entry.product is SubscriptionProduct) {
                 alertController.addAction(UIAlertAction(title: "Simulate purchase", style: .default, handler: { _ in
-                    overrideTracker.overridePurchase(productID: entry.product.productID, with: .purchased)
+                    switch entry.product {
+                        case let nonConsumableProduct as NonConsumableProduct:
+                            overrideTracker.overridePurchase(product: nonConsumableProduct, with: .purchased)
+                        case let subscriptionProduct as SubscriptionProduct:
+                            overrideTracker.overridePurchase(product: subscriptionProduct, with: .purchased)
+                        default:
+                            flintBug("We should not be able to remove overrides on product type: \(entry.product)")
+                            break
+                    }
                     self.refresh()
                 }))
             }
-            if debugOverrideStatus != .notPurchased {
+            if debugOverrideStatus != .notPurchased &&
+                    (entry.product is NonConsumableProduct || entry.product is SubscriptionProduct) {
                 alertController.addAction(UIAlertAction(title: "Simulate not purchased", style: .default, handler: { _ in
-                    overrideTracker.overridePurchase(productID: entry.product.productID, with: .notPurchased)
+                    switch entry.product {
+                        case let nonConsumableProduct as NonConsumableProduct:
+                            overrideTracker.overridePurchase(product: nonConsumableProduct, with: .notPurchased)
+                        case let subscriptionProduct as SubscriptionProduct:
+                            overrideTracker.overridePurchase(product: subscriptionProduct, with: .notPurchased)
+                        default:
+                            flintBug("We should not be able to remove overrides on product type: \(entry.product)")
+                            break
+                    }
                     self.refresh()
                 }))
             }
-            if debugOverrideStatus != .unknown {
+            if debugOverrideStatus != .unknown &&
+                    (entry.product is NonConsumableProduct || entry.product is SubscriptionProduct) {
                 alertController.addAction(UIAlertAction(title: "Simulate unknown", style: .default, handler: { _ in
-                    overrideTracker.overridePurchase(productID: entry.product.productID, with: .unknown)
+                    switch entry.product {
+                        case let nonConsumableProduct as NonConsumableProduct:
+                            overrideTracker.overridePurchase(product: nonConsumableProduct, with: .unknown)
+                        case let subscriptionProduct as SubscriptionProduct:
+                            overrideTracker.overridePurchase(product: subscriptionProduct, with: .unknown)
+                        default:
+                            flintBug("We should not be able to remove overrides on product type: \(entry.product)")
+                            break
+                    }
                     self.refresh()
                 }))
             }

--- a/FlintUISandbox/FakeFeatures.swift
+++ b/FlintUISandbox/FakeFeatures.swift
@@ -9,7 +9,7 @@
 import Foundation
 import FlintCore
 
-let fakeProduct = Product(name: "💎 Premium", description: "Unlock everything", productID: "PREM0001")
+let fakeProduct = NonConsumableProduct(name: "💎 Premium", description: "Unlock everything", productID: "PREM0001")
 
 class FakeFeatures: FeatureGroup {
     static var name = "MyFakeFeaturesAliased"


### PR DESCRIPTION
We need to add support at the API level for at least describing and basic verification of consumable purchases, non-renewing subscriptions and auto-renewing subscription.
