### PR TITLE
Update dependency mechanism

### DIFF
--- a/FlintCore.xcodeproj/project.pbxproj
+++ b/FlintCore.xcodeproj/project.pbxproj
@@ -3474,7 +3474,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				CODE_SIGN_STYLE = Manual;
-				DEVELOPMENT_TEAM = "";
+				DEVELOPMENT_TEAM = 5LUNBYMD4J;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
 					"$(PROJECT_DIR)/Carthage/Build/iOS",

--- a/FlintCore/Actions/Action+Extensions.swift
+++ b/FlintCore/Actions/Action+Extensions.swift
@@ -66,7 +66,7 @@ public extension Action {
 
 /// Default implementation of the Siri and Intents requirements, to ease the out-of-box experience.
 public extension Action {
-    public static var suggestedInvocationPhrase: String? {
+    static var suggestedInvocationPhrase: String? {
         return nil
     }
 

--- a/FlintCore/Conditional Features/ConditionalFeature.swift
+++ b/FlintCore/Conditional Features/ConditionalFeature.swift
@@ -54,7 +54,7 @@ public extension ConditionalFeature {
     /// If so, returns a request that can be used to perform the action, otherwise `nil`.
     ///
     /// The default `isAvailable` implementation will delegate to the `AvailabilityChecker` to see if the feature is available.
-    public static func request<ActionType>(_ actionBinding: ConditionalActionBinding<Self, ActionType>) -> VerifiedActionBinding<Self, ActionType>? {
+    static func request<ActionType>(_ actionBinding: ConditionalActionBinding<Self, ActionType>) -> VerifiedActionBinding<Self, ActionType>? {
         // Sanity checks and footgun avoidance
         Flint.requiresSetup()
         Flint.requiresPrepared(feature: Self.self)
@@ -74,7 +74,7 @@ public extension ConditionalFeature {
     /// Function for binding a conditional feature and action pair, to restrict how this can be done externally by app code.
     ///
     /// - note: This exists only in an extension as it is not an extension point for features to override.
-    public static func action<ActionType>(_ action: ActionType.Type) -> ConditionalActionBinding<Self, ActionType> where ActionType: Action {
+    static func action<ActionType>(_ action: ActionType.Type) -> ConditionalActionBinding<Self, ActionType> where ActionType: Action {
         return ConditionalActionBinding<Self, ActionType>()
     }
 }

--- a/FlintCore/Conditional Features/ConditionalFeatureDefinition.swift
+++ b/FlintCore/Conditional Features/ConditionalFeatureDefinition.swift
@@ -40,7 +40,7 @@ public extension ConditionalFeatureDefinition {
     /// - note: It is safe to invoke this from any thread or queue
     /// - see: `AvailabilityChecker`
     static var isAvailable: Bool? {
-        return Flint.availabilityChecker?.isAvailable(self)
+        return Flint.availabilityChecker.isAvailable(self)
     }
 
     /// Get a human readable description of what constraints are not currently satisfied and hence preventing
@@ -68,7 +68,7 @@ public extension ConditionalFeatureDefinition {
     }
     
     /// Access information about the permissions required by this feature
-    public static var permissions: FeaturePermissionRequirements {
+    static var permissions: FeaturePermissionRequirements {
         let constraints = Flint.constraintsEvaluator.evaluate(for: self)
         
         func _filter(_ permissions: Set<SystemPermissionConstraint>, onStatus matchingStatus: SystemPermissionStatus) -> Set<SystemPermissionConstraint> {
@@ -90,7 +90,7 @@ public extension ConditionalFeatureDefinition {
     }
     
     /// Access information about the purchases required by this feature
-    public static var purchases: FeaturePurchaseRequirements {
+    static var purchases: FeaturePurchaseRequirements {
         // Ugly implementation of this for now until we patch up `FeatureConstraints` internals
         func _extractPurchaseRequirements(_ preconditions: Set<FeaturePreconditionConstraint>) -> Set<PurchaseRequirement> {
             let requirements: [PurchaseRequirement] = preconditions.compactMap {
@@ -115,7 +115,7 @@ public extension ConditionalFeatureDefinition {
     
     /// - return: `true` if this feature is currently disabled at least in part because the user has not toggled it ON
     /// via the Flint user toggles API
-    public static var requiresUserToggle: Bool {
+    static var requiresUserToggle: Bool {
         let constraints = Flint.constraintsEvaluator.evaluate(for: self)
         let preconditionMatching = constraints.preconditions.notSatisfied.first {
             if case .userToggled = $0 {
@@ -134,7 +134,7 @@ public extension ConditionalFeatureDefinition {
     
     /// - return: `true` if this feature is currently disabled at least in part because it requires runtime status
     /// of `isEnabled` to return `true` and it is not currently.
-    public static var requiresRuntimeEnabled: Bool {
+    static var requiresRuntimeEnabled: Bool {
         let constraints = Flint.constraintsEvaluator.evaluate(for: self)
         let preconditionMatching = constraints.preconditions.notSatisfied.first {
             if case .runtimeEnabled = $0 {
@@ -152,7 +152,7 @@ public extension ConditionalFeatureDefinition {
     }
     
     /// Request permissions for all unauthorised permission requirements, using the supplied presenter
-    public static func permissionAuthorisationController(using coordinator: PermissionAuthorisationCoordinator?) -> AuthorisationController? {
+    static func permissionAuthorisationController(using coordinator: PermissionAuthorisationCoordinator?) -> AuthorisationController? {
         let constraints = Flint.constraintsEvaluator.evaluate(for: self)
         guard constraints.permissions.notDetermined.count > 0 else {
             return nil

--- a/FlintCore/Constraints/ConstraintsEvaluator.swift
+++ b/FlintCore/Constraints/ConstraintsEvaluator.swift
@@ -12,7 +12,7 @@ import Foundation
 ///
 /// Implementations are responsible for evaluating all the constraints and returning information about
 /// those that are satisfied or not.
-public protocol ConstraintsEvaluator {
+public protocol ConstraintsEvaluator: AnyObject {
     /// Return a human-readable descriptiong for the constraints of a single feature
     func description(for feature: ConditionalFeatureDefinition.Type) -> String
     

--- a/FlintCore/Constraints/DefaultFeatureConstraintsEvaluator.swift
+++ b/FlintCore/Constraints/DefaultFeatureConstraintsEvaluator.swift
@@ -10,13 +10,14 @@ import Foundation
 
 /// This is the implementation of the constraints evaluator.
 ///
-/// It is threadsafe, you may call this from any thread
+/// It is threadsafe in that you may call this from any thread.
 public class DefaultFeatureConstraintsEvaluator: ConstraintsEvaluator {
     var constraintsByFeature: [FeaturePath:DeclaredFeatureConstraints] = [:]
-    var purchaseEvaluator: FeaturePreconditionConstraintEvaluator?
-    var runtimeEvaluator: FeaturePreconditionConstraintEvaluator = RuntimePreconditionEvaluator()
-    var userToggleEvaluator: FeaturePreconditionConstraintEvaluator?
+    let purchaseEvaluator: FeaturePreconditionConstraintEvaluator?
+    let runtimeEvaluator: FeaturePreconditionConstraintEvaluator = RuntimePreconditionEvaluator()
+    let userToggleEvaluator: FeaturePreconditionConstraintEvaluator?
     let permissionChecker: SystemPermissionChecker
+
     lazy var accessQueue = {
         return SmartDispatchQueue(queue: DispatchQueue(label: "tools.flint.DefaultFeatureConstraintsEvaluator"))
     }()
@@ -25,9 +26,13 @@ public class DefaultFeatureConstraintsEvaluator: ConstraintsEvaluator {
         self.permissionChecker = permissionChecker
         if let purchaseTracker = purchaseTracker {
             purchaseEvaluator = PurchasePreconditionEvaluator(purchaseTracker: purchaseTracker)
+        } else {
+            purchaseEvaluator = nil
         }
         if let userToggles = userToggles {
             userToggleEvaluator = UserTogglePreconditionEvaluator(userToggles: userToggles)
+        } else {
+            userToggleEvaluator = nil
         }
     }
     

--- a/FlintCore/Constraints/FeatureConstraintsBuilder+Extensions.swift
+++ b/FlintCore/Constraints/FeatureConstraintsBuilder+Extensions.swift
@@ -11,14 +11,14 @@ import Foundation
 /// Syntactic sugar
 public extension FeatureConstraintsBuilder {
     /// Call to declare a list of permissions that your feature requires.
-    public func permissions(_ requirements: SystemPermissionConstraint...) {
+    func permissions(_ requirements: SystemPermissionConstraint...) {
         for requirement in requirements {
             permission(requirement)
         }
     }
 
     /// Call to declare a list of purchase requirements that your feature requires
-    public func purchases(_ requirements: PurchaseRequirement...) {
+    func purchases(_ requirements: PurchaseRequirement...) {
         for requirement in requirements {
             purchase(requirement)
         }
@@ -30,7 +30,7 @@ public extension FeatureConstraintsBuilder {
     /// ```
     /// requirements.purchase(anyOf: .init(nonConsumableProduct), .init(creditsProduct, quantity: 5))
     /// ```
-    public func purchase(anyOf requirements: PurchaseRequirement...) {
+    func purchase(anyOf requirements: PurchaseRequirement...) {
         purchase(PurchaseRequirement(products: [], quantity: nil, matchingCriteria: .any, dependencies:requirements))
     }
     
@@ -40,51 +40,51 @@ public extension FeatureConstraintsBuilder {
     /// ```
     /// requirements.purchase(allOf: .init(nonConsumableProduct), .init(creditsProduct, quantity: 5))
     /// ```
-    public func purchase(allOf requirements: PurchaseRequirement...) {
+    func purchase(allOf requirements: PurchaseRequirement...) {
         purchase(PurchaseRequirement(products: [], quantity: nil, matchingCriteria: .all, dependencies:requirements))
     }
     
     /// Call to declare a product that your feature requires
-    public func purchase(_ product: NonConsumableProduct) {
+    func purchase(_ product: NonConsumableProduct) {
         purchase(PurchaseRequirement(product))
     }
 
     /// Call to declare a product that your feature requires
-    public func purchase(_ product: ConsumableProduct, quantity: UInt) {
+    func purchase(_ product: ConsumableProduct, quantity: UInt) {
         purchase(PurchaseRequirement(product, quantity: quantity))
     }
 
     /// Call to declare a product that your feature requires
-    public func purchase(_ product: SubscriptionProduct) {
+    func purchase(_ product: SubscriptionProduct) {
         purchase(PurchaseRequirement(product))
     }
 
     /// Call to declare a list of products that your feature requires. All must be purchased for the constraint to be met
-    public func purchases(_ products: NonConsumableProduct...) {
+    func purchases(_ products: NonConsumableProduct...) {
         purchase(PurchaseRequirement(products: Set(products), matchingCriteria: .all))
     }
 
     /// Convenience function for use when constructing constraints in the constraints builder, where
     /// any of the listed purchases will fulfil the requirement
-    public func purchase(anyOf products: Set<NoQuantityProduct>) {
+    func purchase(anyOf products: Set<NoQuantityProduct>) {
         purchase(PurchaseRequirement(products: products, quantity: nil, matchingCriteria: .any))
     }
     
     /// Convenience function for use when constructing constraints in the constraints builder, where
     /// any of the listed purchases will fulfil the requirement
-    public func purchase(anyOf products: NoQuantityProduct...) {
+    func purchase(anyOf products: NoQuantityProduct...) {
         purchase(PurchaseRequirement(products: Set(products), quantity: nil, matchingCriteria: .any))
     }
     
     /// Convenience function for use when constructing constraints in the constraints builder, where
     /// all of the listed purchases will fulfil the requirement
-    public func purchase(allOf products: NoQuantityProduct...) {
+    func purchase(allOf products: NoQuantityProduct...) {
         purchase(PurchaseRequirement(products: Set(products), quantity: nil, matchingCriteria: .all))
     }
     
     /// Convenience function for use when constructing constraints in the constraints builder, where
     /// all of the listed purchases will fulfil the requirement
-    public func purchase(allOf products: Set<NoQuantityProduct>) {
+    func purchase(allOf products: Set<NoQuantityProduct>) {
         purchase(PurchaseRequirement(products: products, quantity: nil, matchingCriteria: .all))
     }
     
@@ -94,7 +94,7 @@ public extension FeatureConstraintsBuilder {
 public extension FeatureConstraintsBuilder {
     
     /// Set this to the minimum iOS version your feature requires
-    public var iOS: PlatformVersionConstraint {
+    var iOS: PlatformVersionConstraint {
         get {
             flintUsageError("Not supported, you can only assign in this DSL")
         }
@@ -105,7 +105,7 @@ public extension FeatureConstraintsBuilder {
 
     /// Set this to the minimum iOS version your feature requires, if it only supports iOS and all other platforms
     /// should be set to `.unsupported`
-    public var iOSOnly: PlatformVersionConstraint {
+    var iOSOnly: PlatformVersionConstraint {
         get {
             flintUsageError("Not supported, you can only assign in this DSL")
         }
@@ -118,7 +118,7 @@ public extension FeatureConstraintsBuilder {
     }
 
     /// Set this to the minimum watchOS version your feature requires
-    public var watchOS: PlatformVersionConstraint {
+    var watchOS: PlatformVersionConstraint {
         get {
             flintUsageError("Not supported, you can only assign in this DSL")
         }
@@ -129,7 +129,7 @@ public extension FeatureConstraintsBuilder {
 
     /// Set this to the minimum watchOS version your feature requires, if it only supports watchOS and all other platforms
     /// should be set to `.unsupported`
-    public var watchOSOnly: PlatformVersionConstraint {
+    var watchOSOnly: PlatformVersionConstraint {
         get {
             flintUsageError("Not supported, you can only assign in this DSL")
         }
@@ -142,7 +142,7 @@ public extension FeatureConstraintsBuilder {
     }
 
     /// Set this to the minimum tvOS version your feature requires
-    public var tvOS: PlatformVersionConstraint {
+    var tvOS: PlatformVersionConstraint {
         get {
             flintUsageError("Not supported, you can only assign in this DSL")
         }
@@ -153,7 +153,7 @@ public extension FeatureConstraintsBuilder {
 
     /// Set this to the minimum tvOS version your feature requires, if it only supports tvOS and all other platforms
     /// should be set to `.unsupported`
-    public var tvOSOnly: PlatformVersionConstraint {
+    var tvOSOnly: PlatformVersionConstraint {
         get {
             flintUsageError("Not supported, you can only assign in this DSL")
         }
@@ -166,7 +166,7 @@ public extension FeatureConstraintsBuilder {
     }
 
     /// Set this to the minimum macOS version your feature requires
-    public var macOS: PlatformVersionConstraint {
+    var macOS: PlatformVersionConstraint {
         get {
             flintUsageError("Not supported, you can only assign in this DSL")
         }
@@ -177,7 +177,7 @@ public extension FeatureConstraintsBuilder {
 
     /// Set this to the minimum macOS version your feature requires, if it only supports macOS and all other platforms
     /// should be set to `.unsupported`
-    public var macOSOnly: PlatformVersionConstraint {
+    var macOSOnly: PlatformVersionConstraint {
         get {
             flintUsageError("Not supported, you can only assign in this DSL")
         }

--- a/FlintCore/Constraints/Permissions/SystemPermissionChecker.swift
+++ b/FlintCore/Constraints/Permissions/SystemPermissionChecker.swift
@@ -17,7 +17,7 @@ public protocol SystemPermissionCheckerDelegate: AnyObject {
 /// Implementations must be safe to call from any thread.
 ///
 /// - see: `DefaultPermissionChecker`
-public protocol SystemPermissionChecker {
+public protocol SystemPermissionChecker: AnyObject {
     var delegate: SystemPermissionCheckerDelegate? { get set }
     
     /// Must return `true` only if all the permissions are authorised

--- a/FlintCore/Constraints/Preconditions/FeaturePreconditionEvaluator.swift
+++ b/FlintCore/Constraints/Preconditions/FeaturePreconditionEvaluator.swift
@@ -9,7 +9,7 @@
 import Foundation
 
 /// The interface to types that evaluate whether or not a specific precondition has been met.
-public protocol FeaturePreconditionConstraintEvaluator {
+public protocol FeaturePreconditionConstraintEvaluator: AnyObject {
 
     /// - return: `true` only if the precondition is currently satisfied. If the state cannot be determined
     /// yet and will change, return `nil`

--- a/FlintCore/Core/ActionStackTracker.swift
+++ b/FlintCore/Core/ActionStackTracker.swift
@@ -147,7 +147,7 @@ extension ActionStackTracker {
 }
 
 public extension ActionStackTracker {
-    public func copyReport(to path: URL, options: Set<DebugReportOption>) {
+    func copyReport(to path: URL, options: Set<DebugReportOption>) {
         var data = Data()
         let userInitiatedOnly = options.contains(.userInitiatedOnly)
         let filename = options.contains(.machineReadableFormat) ? "action_stacks.json" : "action_stacks.txt"

--- a/FlintCore/Features/Feature.swift
+++ b/FlintCore/Features/Feature.swift
@@ -52,14 +52,14 @@ public protocol Feature: FeatureDefinition {
 public extension Feature {
 
     /// Function for binding a feature and action pair, to restrict how this can be done externally by app code.
-    public static func action<ActionType>(_ action: ActionType.Type) -> StaticActionBinding<Self, ActionType> {
+    static func action<ActionType>(_ action: ActionType.Type) -> StaticActionBinding<Self, ActionType> {
         return StaticActionBinding<Self, ActionType>()
     }
 
     /// Function for binding a feature and action pair, to restrict how this can be done externally by app code.
 #if canImport(Intents) && os(iOS)
     @available(iOS 12, *)
-    public static func action<ActionType>(_ action: ActionType.Type) -> StaticActionBinding<Self, ActionType> where ActionType: IntentAction {
+    static func action<ActionType>(_ action: ActionType.Type) -> StaticActionBinding<Self, ActionType> where ActionType: IntentAction {
         return StaticActionBinding<Self, ActionType>()
     }
 #endif

--- a/FlintCore/Features/FeatureDefinition.swift
+++ b/FlintCore/Features/FeatureDefinition.swift
@@ -95,7 +95,7 @@ public extension FeatureDefinition {
     ///
     /// - param activity: A string that identifies the kind of activity that will be generating log entries, e.g. "bg upload"
     /// - return: A `Logs` value which contains development and production loggers as appropriate at runtime.
-    public static func logs(for activity: String) -> ContextualLoggers {
+    static func logs(for activity: String) -> ContextualLoggers {
         let development: ContextSpecificLogger?
         if let factory = Logging.development {
             development = factory.contextualLogger(with: activity, topicPath: self.identifier)
@@ -114,13 +114,13 @@ public extension FeatureDefinition {
     }
     
     /// Convenience function to set the level of logging for this feature and subfeatures
-    public static func setLoggingLevel(_ level: LoggerLevel) {
+    static func setLoggingLevel(_ level: LoggerLevel) {
         Logging.development?.setLevel(for: self.identifier, to: level)
         Logging.production?.setLevel(for: self.identifier, to: level)
     }
 
     /// Convenience function to turn off logging for this feature and subfeatures
-    public static func disableLogging() {
+    static func disableLogging() {
         setLoggingLevel(.none)
     }
 }

--- a/FlintCore/Features/FeatureGroup.swift
+++ b/FlintCore/Features/FeatureGroup.swift
@@ -29,10 +29,10 @@ public protocol FeatureGroup: FeatureDefinition {
 
 public extension FeatureGroup {
     /// Normally a feature group has no initialisation to do, so we remove the requirement to implement this.
-    public static func prepare(actions: FeatureActionsBuilder) {
+    static func prepare(actions: FeatureActionsBuilder) {
     }
 
-    public static var description: String {
+    static var description: String {
         return "A feature group"
     }
 }

--- a/FlintCore/Purchases/StoreKit-Specific/StoreKitPurchaseTracker.swift
+++ b/FlintCore/Purchases/StoreKit-Specific/StoreKitPurchaseTracker.swift
@@ -59,7 +59,7 @@ public class StoreKitPurchaseTracker: NSObject, PurchaseTracker {
         super.init()
 
         logger?.debug("Loading purchases")
-        try purchaseStore.load().forEach { purchases[$0.productID] = $0 }
+        purchaseStore.load().forEach { purchases[$0.productID] = $0 }
 
         SKPaymentQueue.default().add(self)
     }

--- a/FlintCoreTests/Test Features/DummyFeature.swift
+++ b/FlintCoreTests/Test Features/DummyFeature.swift
@@ -55,6 +55,7 @@ typealias DummyIntentResponse = FlintIntentResponse
 final class DummyIntentAction: IntentAction {
     typealias IntentType = DummyIntent
     typealias PresenterType = IntentResponsePresenter<DummyIntentResponse>
+    typealias IntentResponseType = DummyIntentResponse
     
     static func intent(for input: DummyIntentAction.InputType) -> DummyIntent? {
         return DummyIntent()
@@ -64,7 +65,7 @@ final class DummyIntentAction: IntentAction {
         return NoInput.none
     }
     
-    static func perform(context: ActionContext<NoInput>, presenter: DummyIntentAction.PresenterType, completion: Action.Completion) -> Action.Completion.Status {
+    static func perform(context: ActionContext<NoInput>, presenter: PresenterType, completion: Action.Completion) -> Action.Completion.Status {
         return completion.completedSync(.successWithFeatureTermination)
     }
 }

--- a/FlintUI/iOS/View Controllers/PurchaseBrowserViewController.swift
+++ b/FlintUI/iOS/View Controllers/PurchaseBrowserViewController.swift
@@ -175,6 +175,10 @@ public class PurchaseBrowserViewController: UITableViewController {
             alertController.addAction(UIAlertAction(title: "OK", style: .default, handler: nil))
         }
         
+        let sourceFrame = tableView.cellForRow(at: indexPath)!.frame
+        let popoverSourceFrame = CGRect(x: sourceFrame.midX, y: sourceFrame.midY, width: 44, height: 44)
+        alertController.popoverPresentationController?.sourceView = tableView
+        alertController.popoverPresentationController?.sourceRect = popoverSourceFrame
         present(alertController, animated: true)
     }
     

--- a/FlintUISandbox/AppDelegate.swift
+++ b/FlintUISandbox/AppDelegate.swift
@@ -60,9 +60,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         let fileOutput = try! FileLoggerOutput(name: "uisandbox")
         Logging.setLoggerOutputs(development: [fileOutput], level: .debug, production: nil, level: .none)
 
-        let storeKitTracker = try! StoreKitPurchaseTracker(appGroupIdentifier: FlintAppInfo.appGroupIdentifier)
-        Flint.purchaseTracker = DebugPurchaseTracker(targetPurchaseTracker: storeKitTracker)
-        Flint.setup(FakeFeatures.self)
+        Flint.setup(FakeFeatures.self) { dependencies in
+            let storeKitTracker = try! StoreKitPurchaseTracker(appGroupIdentifier: FlintAppInfo.appGroupIdentifier)
+            dependencies.purchaseTracker = DebugPurchaseTracker(targetPurchaseTracker: storeKitTracker)
+        }
+    
         Flint.register(group: FlintUIFeatures.self)
         
         // Spit out a fake action every few seconds


### PR DESCRIPTION
New pattern for passing optional config closure to Flint setup calls, allowing configuration of custom dependencies while still guaranteeing that logging has been setup in quickSetup, and moving default dependency handling for purchases and user toggles to `quickSetup` only. Using explicit `setup` means you have not purchase tracker or user toggles unless you configure these yourself.

Open question: should availability checker and constraints evaluator be part of this? It makes for an easier hack/circumvention point but is useful for testing.

Fixes #240 