### PR TITLE
Updates to shortcut/intent APIs

### DIFF
--- a/FlintCore/Actions/Action.swift
+++ b/FlintCore/Actions/Action.swift
@@ -121,7 +121,8 @@ public protocol Action {
     /// A suggested Siri Shortcut phrase to show in the Siri UI when adding a shortcut or registering an `NSUserActivity` for
     /// this action.
     ///
-    /// - note: This value is only used if your `activityEligibility` include `.prediction`.
+    /// - note: This value is only used if your `activityEligibility` include `.prediction`, or you when your action creates
+    /// an `INIntent` to donate.
     static var suggestedInvocationPhrase: String? { get }
     
 #if canImport(Intents)

--- a/FlintCore/Activities/PerformIncomingActivityAction.swift
+++ b/FlintCore/Activities/PerformIncomingActivityAction.swift
@@ -18,10 +18,10 @@ final public class PerformIncomingActivityAction: UIAction {
         case noActivityTypeMappingFound
     }
     
-    /// Attempt to resolve the URL against a URL mapping, and execute the action.
+    /// Attempt to perform the action associated with this activity.
     ///
-    /// The completion outcome will fail with error `noURLMappingFound` if the URL does not map to anything
-    /// that Flint knows about.
+    /// The completion outcome will fail with an error if the activity does not map to anything
+    /// that Flint knows about using the `activityType`
     public static func perform(context: ActionContext<NSUserActivity>, presenter: PresentationRouter, completion: Action.Completion) -> Action.Completion.Status {
         context.logs.development?.debug("Finding action executor for activity: \(context.input.activityType), userInfo \(String(describing: context.input.userInfo))")
         

--- a/FlintCore/Siri Intents and Shortcuts/UIKit-Specific/StaticActionBinding+Shortcut+Extensions.swift
+++ b/FlintCore/Siri Intents and Shortcuts/UIKit-Specific/StaticActionBinding+Shortcut+Extensions.swift
@@ -26,8 +26,10 @@ extension StaticActionBinding {
     /// - param input: The input to pass to the action when it is later invoked from the Siri Shortcut by the user.
     /// - param presenter: The `UIViewController` to use to present the view controller
     @available(iOS 12, *)
-    public func addVoiceShortcut(for input: ActionType.InputType, presenter: UIViewController) {
-        VoiceShortcuts.addVoiceShortcut(action: ActionType.self, feature: FeatureType.self, for: input, presenter: presenter)
+    public func addVoiceShortcut(for input: ActionType.InputType,
+                                 presenter: UIViewController,
+                                 completion: @escaping (_ shortcut: INVoiceShortcut?, _ error: Error?) -> Void) {
+        VoiceShortcuts.addVoiceShortcut(action: ActionType.self, feature: FeatureType.self, for: input, presenter: presenter, completion: completion)
     }
 }
 
@@ -82,8 +84,23 @@ extension StaticActionBinding where ActionType: IntentAction {
     /// - note: This variant exists for the specialisation that will call `intent(for:)` on the Action to create an
     /// an intent for the shortcut.
     @available(iOS 12, *)
-    public func addVoiceShortcut(for input: ActionType.InputType, presenter: UIViewController) {
-        VoiceShortcuts.addVoiceShortcut(action: ActionType.self, feature: FeatureType.self, for: input, presenter: presenter)
+    public func addVoiceShortcut(input: ActionType.InputType,
+                                 presenter: UIViewController,
+                                 completion: @escaping (_ shortcut: INVoiceShortcut?, _ error: Error?) -> Void) {
+        VoiceShortcuts.addVoiceShortcut(action: ActionType.self,
+                                        feature: FeatureType.self,
+                                        for: input,
+                                        presenter: presenter,
+                                        completion: completion)
+    }
+
+    @available(iOS 12, *)
+    public func editVoiceShortcut(_ shortcut: INVoiceShortcut,
+                                  presenter: UIViewController,
+                                  completion: @escaping (_ shortcut: INVoiceShortcut?, _ deleted: Bool, _ error: Error?) -> Void) {
+        VoiceShortcuts.editVoiceShortcut(shortcut,
+                                         presenter: presenter,
+                                         completion: completion)
     }
 
     /// Create an `INShortcut` instance for the given input. Use when pre-registering shortcuts with `INVoiceShortcuteCenter`

--- a/FlintCore/Siri Intents and Shortcuts/UIKit-Specific/StaticActionBinding+Shortcut+Extensions.swift
+++ b/FlintCore/Siri Intents and Shortcuts/UIKit-Specific/StaticActionBinding+Shortcut+Extensions.swift
@@ -88,7 +88,7 @@ extension StaticActionBinding where ActionType: IntentAction {
 
     /// Create an `INShortcut` instance for the given input. Use when pre-registering shortcuts with `INVoiceShortcuteCenter`
     @available(iOS 12, *)
-    public static func shortcut(input: ActionType.InputType) -> INShortcut? {
+    public func shortcut(input: ActionType.InputType) -> INShortcut? {
         guard let shortcutIntent = ActionType.intent(for: input) else {
             return nil
         }

--- a/FlintCore/Siri Intents and Shortcuts/UIKit-Specific/StaticActionBinding+Shortcut+Extensions.swift
+++ b/FlintCore/Siri Intents and Shortcuts/UIKit-Specific/StaticActionBinding+Shortcut+Extensions.swift
@@ -13,12 +13,10 @@ import UIKit
 extension StaticActionBinding {
 
     /// Call to invoke the system "Add Voice Shortcut" view controller for the given input to the conditionally-available
-    /// action represented by this action request. The action must support creating an `INIntent` for a custom intent extension
-    /// to be invoked, or creating an `NSUserActivity` using Flint's Activities conventions.
+    /// action represented by this action request. The action must support creating an `NSUserActivity` using Flint's Activities conventions.
     ///
-    /// This will create a shortcut that invokes the `INIntent` returned by the `Action`'s `intent(for:)` function.
-    /// If that function returns nil (or is not defined by your `Action`), it will attempt to create an `NSUserActivity`
-    /// for the `Action` and instead use that. If the `Action` does not support `Activities`, this will fail.
+    /// This will create a shortcut that invokes the activity created for the `Action`'s.
+    /// If the `Action` does not support `Activities`, this will fail.
     ///
     /// - param input: The input to pass to the action when it is later invoked from the Siri Shortcut by the user.
     /// - param presenter: The `UIViewController` to use to present the view controller
@@ -65,12 +63,35 @@ extension StaticActionBinding where ActionType: IntentAction {
         return .init(outcome: outcome)
     }
 
+    /// Call to invoke the system "Add Voice Shortcut" view controller for the given input to the conditionally-available
+    /// action represented by this action request. The action must support creating an `INIntent` for a custom intent extension
+    /// to be invoked.
+    ///
+    /// This will create a shortcut that invokes the `INIntent` returned by the `Action`'s `intent(for:)` function.
+    /// If that function returns nil (or is not defined by your `Action`), it will attempt to create an `NSUserActivity`
+    /// for the `Action` and instead use that. If the `Action` does not support `Activities`, this will fail.
+    ///
+    /// - param input: The input to pass to the action when it is later invoked from the Siri Shortcut by the user.
+    /// - param presenter: The `UIViewController` to use to present the view controller
+    ///
+    /// - note: This variant exists for the specialisation that will call `intent(for:)` on the Action to create an
+    /// an intent for the shortcut.
+    @available(iOS 12, *)
+    public func addVoiceShortcut(for input: ActionType.InputType, presenter: UIViewController) {
+        VoiceShortcuts.addVoiceShortcut(action: ActionType.self, feature: FeatureType.self, for: input, presenter: presenter)
+    }
+
     /// Donate an intent-based shortcut that will invoke this `Action` to Siri for the given input.
     @available(iOS 12, *)
     public func donateToSiri(for input: ActionType.InputType) {
         guard let intent = ActionType.intent(for: input) else {
             flintUsageError("Cannot donate intent to Siri, action type \(ActionType.self) did not return an intent for input: \(input).")
         }
+        
+        if intent.suggestedInvocationPhrase == nil {
+            intent.suggestedInvocationPhrase = ActionType.suggestedInvocationPhrase
+        }
+        
         if let request = IntentShortcutDonationFeature.donateShortcut.request() {
             let intentWrapper = FlintIntentWrapper(intent: intent)
             request.perform(input: intentWrapper)

--- a/FlintCore/Siri Intents and Shortcuts/UIKit-Specific/StaticActionBinding+Shortcut+Extensions.swift
+++ b/FlintCore/Siri Intents and Shortcuts/UIKit-Specific/StaticActionBinding+Shortcut+Extensions.swift
@@ -28,7 +28,7 @@ extension StaticActionBinding {
     @available(iOS 12, *)
     public func addVoiceShortcut(for input: ActionType.InputType,
                                  presenter: UIViewController,
-                                 completion: @escaping (_ shortcut: INVoiceShortcut?, _ error: Error?) -> Void) {
+                                 completion: @escaping (_ result: AddVoiceShortcutResult) -> Void) {
         VoiceShortcuts.addVoiceShortcut(action: ActionType.self, feature: FeatureType.self, for: input, presenter: presenter, completion: completion)
     }
 }
@@ -86,7 +86,7 @@ extension StaticActionBinding where ActionType: IntentAction {
     @available(iOS 12, *)
     public func addVoiceShortcut(input: ActionType.InputType,
                                  presenter: UIViewController,
-                                 completion: @escaping (_ shortcut: INVoiceShortcut?, _ error: Error?) -> Void) {
+                                 completion: @escaping (_ result: AddVoiceShortcutResult) -> Void) {
         VoiceShortcuts.addVoiceShortcut(action: ActionType.self,
                                         feature: FeatureType.self,
                                         for: input,
@@ -97,7 +97,7 @@ extension StaticActionBinding where ActionType: IntentAction {
     @available(iOS 12, *)
     public func editVoiceShortcut(_ shortcut: INVoiceShortcut,
                                   presenter: UIViewController,
-                                  completion: @escaping (_ shortcut: INVoiceShortcut?, _ deleted: Bool, _ error: Error?) -> Void) {
+                                  completion: @escaping (_ result: EditVoiceShortcutResult) -> Void) {
         VoiceShortcuts.editVoiceShortcut(shortcut,
                                          presenter: presenter,
                                          completion: completion)

--- a/FlintCore/Siri Intents and Shortcuts/UIKit-Specific/StaticActionBinding+Shortcut+Extensions.swift
+++ b/FlintCore/Siri Intents and Shortcuts/UIKit-Specific/StaticActionBinding+Shortcut+Extensions.swift
@@ -8,6 +8,11 @@
 
 import Foundation
 import UIKit
+#if os(iOS)
+#if canImport(Intents)
+import Intents
+#endif
+#endif
 
 #if canImport(Network) && os(iOS)
 extension StaticActionBinding {
@@ -79,6 +84,15 @@ extension StaticActionBinding where ActionType: IntentAction {
     @available(iOS 12, *)
     public func addVoiceShortcut(for input: ActionType.InputType, presenter: UIViewController) {
         VoiceShortcuts.addVoiceShortcut(action: ActionType.self, feature: FeatureType.self, for: input, presenter: presenter)
+    }
+
+    /// Create an `INShortcut` instance for the given input. Use when pre-registering shortcuts with `INVoiceShortcuteCenter`
+    @available(iOS 12, *)
+    public static func shortcut(input: ActionType.InputType) -> INShortcut? {
+        guard let shortcutIntent = ActionType.intent(for: input) else {
+            return nil
+        }
+        return INShortcut(intent: shortcutIntent)
     }
 
     /// Donate an intent-based shortcut that will invoke this `Action` to Siri for the given input.

--- a/FlintCore/Siri Intents and Shortcuts/UIKit-Specific/VerifiedActionBinding+Shortcut+Extensions.swift
+++ b/FlintCore/Siri Intents and Shortcuts/UIKit-Specific/VerifiedActionBinding+Shortcut+Extensions.swift
@@ -8,6 +8,11 @@
 
 import Foundation
 import UIKit
+#if os(iOS)
+#if canImport(Intents)
+import Intents
+#endif
+#endif
 
 // Workaround for inability to compile against just iOS 12+, using the new "Network" framework as an indicator
 #if canImport(Network) && os(iOS)
@@ -77,13 +82,22 @@ extension VerifiedActionBinding where ActionType: IntentAction {
     /// - note: This variant exists for the specialisation that will call `intent(for:)` on the Action to create an
     /// an intent for the shortcut.
     @available(iOS 12, *)
-    public func addVoiceShortcut(for input: ActionType.InputType, presenter: UIViewController) {
+    public func addVoiceShortcut(input: ActionType.InputType, presenter: UIViewController) {
         VoiceShortcuts.addVoiceShortcut(action: ActionType.self, feature: FeatureType.self, for: input, presenter: presenter)
     }
     
+    /// Create an `INShortcut` instance for the given input. Use when pre-registering shortcuts with `INVoiceShortcuteCenter`
+    @available(iOS 12, *)
+    public static func shortcut(input: ActionType.InputType) -> INShortcut? {
+        guard let shortcutIntent = ActionType.intent(for: input) else {
+            return nil
+        }
+        return INShortcut(intent: shortcutIntent)
+    }
+
     /// Donate an intent-based shortcut to this `Action` to Siri for the given input.
     @available(iOS 12, *)
-    public func donateToSiri(for input: ActionType.InputType) {
+    public func donateToSiri(input: ActionType.InputType) {
         guard let intent = ActionType.intent(for: input) else {
             flintUsageError("Cannot donate intent to Siri, action type \(ActionType.self) did not return an intent for input: \(input).")
         }

--- a/FlintCore/Siri Intents and Shortcuts/UIKit-Specific/VerifiedActionBinding+Shortcut+Extensions.swift
+++ b/FlintCore/Siri Intents and Shortcuts/UIKit-Specific/VerifiedActionBinding+Shortcut+Extensions.swift
@@ -27,7 +27,7 @@ extension VerifiedActionBinding {
     /// - param input: The input to pass to the action when it is later invoked from the Siri Shortcut by the user.
     /// - param presenter: The `UIViewController` to use to present the view controller
     @available(iOS 12, *)
-    public func addVoiceShortcut(for input: ActionType.InputType, presenter: UIViewController, completion: @escaping (_ shortcut: INVoiceShortcut?, _ error: Error?) -> Void) {
+    public func addVoiceShortcut(for input: ActionType.InputType, presenter: UIViewController, completion: @escaping (_ result: AddVoiceShortcutResult) -> Void) {
         VoiceShortcuts.addVoiceShortcut(action: ActionType.self, feature: FeatureType.self, for: input, presenter: presenter, completion: completion)
     }
 }
@@ -84,7 +84,7 @@ extension VerifiedActionBinding where ActionType: IntentAction {
     @available(iOS 12, *)
     public func addVoiceShortcut(input: ActionType.InputType,
                                  presenter: UIViewController,
-                                 completion: @escaping (_ shortcut: INVoiceShortcut?, _ error: Error?) -> Void) {
+                                 completion: @escaping (_ result: AddVoiceShortcutResult) -> Void) {
         VoiceShortcuts.addVoiceShortcut(action: ActionType.self,
                                         feature: FeatureType.self,
                                         for: input,
@@ -95,7 +95,7 @@ extension VerifiedActionBinding where ActionType: IntentAction {
     @available(iOS 12, *)
     public func editVoiceShortcut(_ shortcut: INVoiceShortcut,
                                   presenter: UIViewController,
-                                  completion: @escaping (_ shortcut: INVoiceShortcut?, _ deleted: Bool, _ error: Error?) -> Void) {
+                                  completion: @escaping (_ result: EditVoiceShortcutResult) -> Void) {
         VoiceShortcuts.editVoiceShortcut(shortcut,
                                          presenter: presenter,
                                          completion: completion)

--- a/FlintCore/Siri Intents and Shortcuts/UIKit-Specific/VerifiedActionBinding+Shortcut+Extensions.swift
+++ b/FlintCore/Siri Intents and Shortcuts/UIKit-Specific/VerifiedActionBinding+Shortcut+Extensions.swift
@@ -14,12 +14,10 @@ import UIKit
 extension VerifiedActionBinding {
 
     /// Call to invoke the system "Add Voice Shortcut" view controller for the given input to the conditionally-available
-    /// action represented by this action request. The action must support creating an `INIntent` for a custom intent extension
-    /// to be invoked, or creating an `NSUserActivity` using Flint's Activities conventions.
+    /// action represented by this action request. The action must support creating an `NSUserActivity` using Flint's Activities conventions.
     ///
-    /// This will create a shortcut that invokes the `INIntent` returned by the `Action`'s `intent(for:)` function.
-    /// If that function returns nil (or is not defined by your `Action`), it will attempt to create an `NSUserActivity`
-    /// for the `Action` and instead use that. If the `Action` does not support `Activities`, this will fail.
+    /// This will create a shortcut that invokes the activity created for the `Action`'s.
+    /// If the `Action` does not support `Activities`, this will fail.
     ///
     /// - param input: The input to pass to the action when it is later invoked from the Siri Shortcut by the user.
     /// - param presenter: The `UIViewController` to use to present the view controller
@@ -65,12 +63,35 @@ extension VerifiedActionBinding where ActionType: IntentAction {
         return .init(outcome: outcome)
     }
 
+    /// Call to invoke the system "Add Voice Shortcut" view controller for the given input to the conditionally-available
+    /// action represented by this action request. The action must support creating an `INIntent` for a custom intent extension
+    /// to be invoked.
+    ///
+    /// This will create a shortcut that invokes the `INIntent` returned by the `Action`'s `intent(for:)` function.
+    /// If that function returns nil (or is not defined by your `Action`), it will attempt to create an `NSUserActivity`
+    /// for the `Action` and instead use that. If the `Action` does not support `Activities`, this will fail.
+    ///
+    /// - param input: The input to pass to the action when it is later invoked from the Siri Shortcut by the user.
+    /// - param presenter: The `UIViewController` to use to present the view controller
+    ///
+    /// - note: This variant exists for the specialisation that will call `intent(for:)` on the Action to create an
+    /// an intent for the shortcut.
+    @available(iOS 12, *)
+    public func addVoiceShortcut(for input: ActionType.InputType, presenter: UIViewController) {
+        VoiceShortcuts.addVoiceShortcut(action: ActionType.self, feature: FeatureType.self, for: input, presenter: presenter)
+    }
+    
     /// Donate an intent-based shortcut to this `Action` to Siri for the given input.
     @available(iOS 12, *)
     public func donateToSiri(for input: ActionType.InputType) {
         guard let intent = ActionType.intent(for: input) else {
             flintUsageError("Cannot donate intent to Siri, action type \(ActionType.self) did not return an intent for input: \(input).")
         }
+
+        if intent.suggestedInvocationPhrase == nil {
+            intent.suggestedInvocationPhrase = ActionType.suggestedInvocationPhrase
+        }
+
         if let request = IntentShortcutDonationFeature.donateShortcut.request() {
             let intentWrapper = FlintIntentWrapper(intent: intent)
             request.perform(input: intentWrapper)

--- a/FlintCore/Siri Intents and Shortcuts/UIKit-Specific/VerifiedActionBinding+Shortcut+Extensions.swift
+++ b/FlintCore/Siri Intents and Shortcuts/UIKit-Specific/VerifiedActionBinding+Shortcut+Extensions.swift
@@ -88,7 +88,7 @@ extension VerifiedActionBinding where ActionType: IntentAction {
     
     /// Create an `INShortcut` instance for the given input. Use when pre-registering shortcuts with `INVoiceShortcuteCenter`
     @available(iOS 12, *)
-    public static func shortcut(input: ActionType.InputType) -> INShortcut? {
+    public func shortcut(input: ActionType.InputType) -> INShortcut? {
         guard let shortcutIntent = ActionType.intent(for: input) else {
             return nil
         }

--- a/FlintCore/Siri Intents and Shortcuts/UIKit-Specific/VerifiedActionBinding+Shortcut+Extensions.swift
+++ b/FlintCore/Siri Intents and Shortcuts/UIKit-Specific/VerifiedActionBinding+Shortcut+Extensions.swift
@@ -27,8 +27,8 @@ extension VerifiedActionBinding {
     /// - param input: The input to pass to the action when it is later invoked from the Siri Shortcut by the user.
     /// - param presenter: The `UIViewController` to use to present the view controller
     @available(iOS 12, *)
-    public func addVoiceShortcut(for input: ActionType.InputType, presenter: UIViewController) {
-        VoiceShortcuts.addVoiceShortcut(action: ActionType.self, feature: FeatureType.self, for: input, presenter: presenter)
+    public func addVoiceShortcut(for input: ActionType.InputType, presenter: UIViewController, completion: @escaping (_ shortcut: INVoiceShortcut?, _ error: Error?) -> Void) {
+        VoiceShortcuts.addVoiceShortcut(action: ActionType.self, feature: FeatureType.self, for: input, presenter: presenter, completion: completion)
     }
 }
 
@@ -82,10 +82,25 @@ extension VerifiedActionBinding where ActionType: IntentAction {
     /// - note: This variant exists for the specialisation that will call `intent(for:)` on the Action to create an
     /// an intent for the shortcut.
     @available(iOS 12, *)
-    public func addVoiceShortcut(input: ActionType.InputType, presenter: UIViewController) {
-        VoiceShortcuts.addVoiceShortcut(action: ActionType.self, feature: FeatureType.self, for: input, presenter: presenter)
+    public func addVoiceShortcut(input: ActionType.InputType,
+                                 presenter: UIViewController,
+                                 completion: @escaping (_ shortcut: INVoiceShortcut?, _ error: Error?) -> Void) {
+        VoiceShortcuts.addVoiceShortcut(action: ActionType.self,
+                                        feature: FeatureType.self,
+                                        for: input,
+                                        presenter: presenter,
+                                        completion: completion)
     }
-    
+
+    @available(iOS 12, *)
+    public func editVoiceShortcut(_ shortcut: INVoiceShortcut,
+                                  presenter: UIViewController,
+                                  completion: @escaping (_ shortcut: INVoiceShortcut?, _ deleted: Bool, _ error: Error?) -> Void) {
+        VoiceShortcuts.editVoiceShortcut(shortcut,
+                                         presenter: presenter,
+                                         completion: completion)
+    }
+
     /// Create an `INShortcut` instance for the given input. Use when pre-registering shortcuts with `INVoiceShortcuteCenter`
     @available(iOS 12, *)
     public func shortcut(input: ActionType.InputType) -> INShortcut? {

--- a/FlintCore/Siri Intents and Shortcuts/UIKit-Specific/VoiceShortcuts.swift
+++ b/FlintCore/Siri Intents and Shortcuts/UIKit-Specific/VoiceShortcuts.swift
@@ -145,6 +145,7 @@ class VoiceShortcuts {
     func show(for voiceShortcut: INVoiceShortcut, with presenter: UIViewController, completion: @escaping (_ result: EditVoiceShortcutResult) -> Void) {
         let editVoiceShortcutViewController = INUIEditVoiceShortcutViewController(voiceShortcut: voiceShortcut)
         editVoiceShortcutViewController.delegate = self
+        self.completion = completion
         presenter.present(editVoiceShortcutViewController, animated: true)
         self.editVoiceShortcutViewController = editVoiceShortcutViewController
     }


### PR DESCRIPTION
Numerous new API tweaks fell out of updating Hobson app to support shortcuts.

* A new API `shortcut(input:)` to return `INShortcut` to support registering suggested shortcuts #
* Extra overloads of `addVoiceShortcut` to support intent-based shortcuts (previously just activity used because of generic type issues) #253 
* New `editVoiceShortcut` API to support editing/removing previously registered voice shortcut
* New completion argument to `addVoiceShortcut` & `editVoiceShortcut` functions so app UI can detected changes and cancellation
* Argument name changes away from `xxx(for:)` to `xxx(input:)` to increase consistency
* Automatically use `suggestedVoicePhrase` for intent shortcuts if no explicit shortcut set on the intent. #252 
