### PR TITLE
Add Analytics feature and fix bug in UISandbox use of Activities

### DIFF
--- a/FlintCore.xcodeproj/project.pbxproj
+++ b/FlintCore.xcodeproj/project.pbxproj
@@ -766,6 +766,10 @@
 		49DFB7E120A3464800D3AE68 /* FeaturePermissionRequirements.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49DFB7DD20A3464800D3AE68 /* FeaturePermissionRequirements.swift */; };
 		49E1A231203C31C900F7555C /* FlintInternal.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49E1A230203C31C900F7555C /* FlintInternal.swift */; };
 		49E1A233203C35C800F7555C /* RouteScope.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49E1A232203C35C800F7555C /* RouteScope.swift */; };
+		49E49159227DEBDE0071ED74 /* AnalyticsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49E49158227DEBDE0071ED74 /* AnalyticsFeature.swift */; };
+		49E4915A227DEBDF0071ED74 /* AnalyticsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49E49158227DEBDE0071ED74 /* AnalyticsFeature.swift */; };
+		49E4915B227DEBDF0071ED74 /* AnalyticsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49E49158227DEBDE0071ED74 /* AnalyticsFeature.swift */; };
+		49E4915C227DEBDF0071ED74 /* AnalyticsFeature.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49E49158227DEBDE0071ED74 /* AnalyticsFeature.swift */; };
 		49EA0BCE208B874900B9A32E /* SmartDispatchQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49EA0BCD208B874900B9A32E /* SmartDispatchQueue.swift */; };
 		49EA0BCF208B874900B9A32E /* SmartDispatchQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49EA0BCD208B874900B9A32E /* SmartDispatchQueue.swift */; };
 		49EA0BD0208B874900B9A32E /* SmartDispatchQueue.swift in Sources */ = {isa = PBXBuildFile; fileRef = 49EA0BCD208B874900B9A32E /* SmartDispatchQueue.swift */; };
@@ -1124,6 +1128,7 @@
 		49DFB7DD20A3464800D3AE68 /* FeaturePermissionRequirements.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FeaturePermissionRequirements.swift; sourceTree = "<group>"; };
 		49E1A230203C31C900F7555C /* FlintInternal.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlintInternal.swift; sourceTree = "<group>"; };
 		49E1A232203C35C800F7555C /* RouteScope.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RouteScope.swift; sourceTree = "<group>"; };
+		49E49158227DEBDE0071ED74 /* AnalyticsFeature.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnalyticsFeature.swift; sourceTree = "<group>"; };
 		49EA0BCD208B874900B9A32E /* SmartDispatchQueue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SmartDispatchQueue.swift; sourceTree = "<group>"; };
 		49EFE2BB20C3F4DA00063E5F /* SpeechRecognitionPermissionAdapter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SpeechRecognitionPermissionAdapter.swift; sourceTree = "<group>"; };
 		49F2CF211FF7B56B004F16EF /* NoPresenter.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NoPresenter.swift; sourceTree = "<group>"; };
@@ -1625,6 +1630,7 @@
 				49A999F91FF7FA6700A64E8C /* AnalyticsReporting.swift */,
 				49A999FB1FF7FC5200A64E8C /* ConsoleAnalyticsProvider.swift */,
 				49DB925F20757D9500F758DC /* AnalyticsProvider.swift */,
+				49E49158227DEBDE0071ED74 /* AnalyticsFeature.swift */,
 			);
 			path = Analytics;
 			sourceTree = "<group>";
@@ -2194,6 +2200,7 @@
 				496F8FD5203EEBDA003AB29B /* TopicPath+Extensions.swift in Sources */,
 				494C27A420C01CE400053FF7 /* MotionPermissionAdapter.swift in Sources */,
 				496136D02099013000291885 /* PhotosPermissionAdapter.swift in Sources */,
+				49E4915A227DEBDF0071ED74 /* AnalyticsFeature.swift in Sources */,
 				49DFB7CB20A2DFA600D3AE68 /* DefaultAuthorisationController.swift in Sources */,
 				495CBD8F223D6E1F00233816 /* NonConsumableProduct.swift in Sources */,
 				4946FAC6208E23740097E10E /* ActionPerformOutcome.swift in Sources */,
@@ -2421,6 +2428,7 @@
 				496136BD209900BC00291885 /* SystemPermissionChecker.swift in Sources */,
 				4921705D20D25625007D6883 /* ActivityCodable.swift in Sources */,
 				496F8FE9203EEBDA003AB29B /* StaticActionBinding.swift in Sources */,
+				49E4915B227DEBDF0071ED74 /* AnalyticsFeature.swift in Sources */,
 				496136DB2099017400291885 /* DefaultPermissionChecker.swift in Sources */,
 				496F8FB7203EEBD4003AB29B /* URLMappings.swift in Sources */,
 				4996D6FF22748D7500CDCAB0 /* IntentAction+Internal+Extensions.swift in Sources */,
@@ -2738,6 +2746,7 @@
 				4956D5D720986BDE002A2A35 /* FeatureConstraintsBuilder.swift in Sources */,
 				4927FEF1208A3B7C00163576 /* ActivityType.swift in Sources */,
 				496F8F7C203EEBB3003AB29B /* Logging.swift in Sources */,
+				49E4915C227DEBDF0071ED74 /* AnalyticsFeature.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -2947,6 +2956,7 @@
 				4927FF00208A542700163576 /* PublishActivityRequest.swift in Sources */,
 				49DFB7CA20A2DFA600D3AE68 /* DefaultAuthorisationController.swift in Sources */,
 				498A89582069695100457D66 /* FocusFeature.swift in Sources */,
+				49E49159227DEBDE0071ED74 /* AnalyticsFeature.swift in Sources */,
 				491211BD2158FC8E00B199C4 /* SiriIntentsFeature.swift in Sources */,
 				491A348B21E7E77D00E81D58 /* IntentResponsePresenter.swift in Sources */,
 			);

--- a/FlintCore/Activities/ActionActivityMappings.swift
+++ b/FlintCore/Activities/ActionActivityMappings.swift
@@ -87,7 +87,7 @@ class ActionActivityMappings {
         // The action can populate or veto publishing this activity by cancelling the builder passed in.
         // Introduce a new scope to prevent accidentally use of the wrong activity instance
         let builder = ActivityBuilder(activityID: activityID, action: action, input: input, appLink: appLink)
-        let function: (ActivityBuilder<ActionType>) -> Void = action.prepareActivity
+        let function: (ActivityBuilder<ActionType>) throws -> Void = action.prepareActivity
         let activity = try builder.build(function)
         return activity
     }

--- a/FlintCore/Analytics/AnalyticsFeature.swift
+++ b/FlintCore/Analytics/AnalyticsFeature.swift
@@ -1,0 +1,30 @@
+//
+//  AnalyticsFeature.swift
+//  FlintCore
+//
+//  Created by Marc Palmer on 04/05/2019.
+//  Copyright © 2019 Montana Floss Co. Ltd. All rights reserved.
+//
+
+import Foundation
+
+/// The Analytics Feature sends analytics events for qualifying actions to your analytics provider.
+final public class AnalyticsFeature: ConditionalFeature {
+    public static func constraints(requirements: FeatureConstraintsBuilder) {
+        requirements.runtimeEnabled()
+    }
+
+    /// Set this to `false` at runtime to disable Timeline
+    public static var isEnabled: Bool? = true
+    
+    public static var description: String = "Sends analytic events for qualifying actions to your analytics provider"
+
+    public static var provider: AnalyticsProvider?
+    
+    public static func prepare(actions: FeatureActionsBuilder) {
+        if isAvailable == true {
+            let analyticsProvider = self.provider ?? ConsoleAnalyticsProvider()
+            Flint.dispatcher.add(observer: AnalyticsReporting(provider: analyticsProvider))
+        }
+    }
+}

--- a/FlintCore/Analytics/AnalyticsReporting.swift
+++ b/FlintCore/Analytics/AnalyticsReporting.swift
@@ -14,11 +14,12 @@ import Foundation
 /// This allows internal or third party frameworks that use Flint to expose functionality that you also track with analytics,
 /// without them directly linking to the analytics package.
 ///
-/// To use Analytics reporting, create an instance of this at runtime and add it to the ActionDispatcher observers:
+/// To use Analytics reporting, you need to make sure AnalyticsFeature.isEnabled is set to true,
+/// and you need to set an implementation of `AnalyticsProvider` to the `AnalyticsFeature.provider` property before Flint
+/// `setup` is called. By default this includes just a default console analytics provider.
 ///
 /// ```
-/// let myAnalyticsProvider = ConsoleAnalyticsProvider()
-/// Flint.dispatcher.add(observer: AnalyticsReporting(provider: myAnalyticsProvider))
+/// AnalyticsFeature.provider = MyGoogleAnalyticsProvider()
 /// ```
 ///
 /// - see: `AnalyticsProvider` for the protocol to conform to, to wire up your actual analytics service such as Mixpanel,

--- a/FlintCore/Core/FlintFeatures.swift
+++ b/FlintCore/Core/FlintFeatures.swift
@@ -20,6 +20,7 @@ public final class FlintFeatures: FeatureGroup {
         ActivitiesFeature.self,
         TimelineFeature.self,
         FocusFeature.self,
+        AnalyticsFeature.self,
         SiriIntentsFeature.self
     ]
 }

--- a/FlintCore/Logging/DefaultContextSpecificLogger.swift
+++ b/FlintCore/Logging/DefaultContextSpecificLogger.swift
@@ -24,18 +24,18 @@ public class DefaultContextSpecificLogger: ContextSpecificLogger {
     }
 
     public func info(_ content: @escaping @autoclosure () -> String) {
-        target.log(level: .info, context: context, content: content)
+        target.log(level: .info, context: context, content: content())
     }
     
     public func error(_ content: @escaping @autoclosure () -> String) {
-        target.log(level: .error, context: context, content: content)
+        target.log(level: .error, context: context, content: content())
     }
     
     public func warning(_ content: @escaping @autoclosure () -> String) {
-        target.log(level: .warning, context: context, content: content)
+        target.log(level: .warning, context: context, content: content())
     }
     
     public func debug(_ content: @escaping @autoclosure () -> String) {
-        target.log(level: .debug, context: context, content: content)
+        target.log(level: .debug, context: context, content: content())
     }
 }

--- a/FlintUISandbox/FakeFeatures.swift
+++ b/FlintUISandbox/FakeFeatures.swift
@@ -58,10 +58,12 @@ extension String: RouteParametersCodable {
 final class DoSomethingFakeAction: UIAction {
     typealias InputType = String?
     typealias PresenterType = NoPresenter
+
+    static let analyticsID: String? = "do-something-fake"
     
     static var activityEligibility: Set<ActivityEligibility> = [.handoff, .prediction]
 
-    static func prepareActivity(_ activity: ActivityBuilder<DoSomethingFakeAction>) {
+    static func prepareActivity(_ activity: ActivityBuilder<DoSomethingFakeAction>) throws {
         activity.title = "Do a fake thing"
         activity.subtitle = "This will show up in Siri shortcuts on iOS 12"
         activity.requiredUserInfoKeys = ["fake"]


### PR DESCRIPTION
Turns out Activities was not resolving the correct `prepare` function since we added the throws requirement but it wasn’t added to the sandbox’s fake action.

Fixes #9 