### PR TITLE
Combine dev + prod logs for focus logging purposes. 

### DIFF
--- a/FlintCore/Focus/FocusFeature.swift
+++ b/FlintCore/Focus/FocusFeature.swift
@@ -24,19 +24,16 @@ final public class FocusFeature: ConditionalFeature {
     public static var defaultMaxLogEvents: Int = 1000
     
     public struct Dependencies {
-        public let developmentFocusLogging: FocusLogging?
-        public let productionFocusLogging: FocusLogging?
+        public let focusLoggingHistory: FocusLogging?
         public let focusSelection: FocusSelection?
 
         fileprivate init() {
-            developmentFocusLogging = nil
-            productionFocusLogging = nil
+            focusLoggingHistory = nil
             focusSelection = nil
         }
         
-        fileprivate init(developmentFocusLogging: FocusLogging?, productionFocusLogging: FocusLogging?, focusSelection: FocusSelection?) {
-            self.developmentFocusLogging = developmentFocusLogging
-            self.productionFocusLogging = productionFocusLogging
+        fileprivate init(focusLoggingHistory: FocusLogging?, focusSelection: FocusSelection?) {
+            self.focusLoggingHistory = focusLoggingHistory
             self.focusSelection = focusSelection
         }
     }
@@ -61,21 +58,17 @@ final public class FocusFeature: ConditionalFeature {
         if isAvailable == true {
             var developmentLogging: FocusLogging?
             var productionLogging: FocusLogging?
+
+            let focusLoggingHistory = FocusLogging(maxCount: defaultMaxLogEvents)
             if let development = Logging.development {
-                let developmentFocusLogging = FocusLogging(maxCount: defaultMaxLogEvents)
-                development.add(output: developmentFocusLogging)
-                developmentLogging = developmentFocusLogging
+                development.add(output: focusLoggingHistory)
             }
             if let production = Logging.production {
-                let productionFocusLogging = FocusLogging(maxCount: defaultMaxLogEvents)
-                production.add(output: productionFocusLogging)
-                productionLogging = productionFocusLogging
+                production.add(output: focusLoggingHistory)
             }
             dependencies = Dependencies(
-                developmentFocusLogging: developmentLogging,
-                productionFocusLogging: productionLogging,
+                focusLoggingHistory: focusLoggingHistory,
                 focusSelection: DefaultFocusSelection())
-            
         }
     }
 }

--- a/FlintUI/Features/FocusLogDataAccessFeature.swift
+++ b/FlintUI/Features/FocusLogDataAccessFeature.swift
@@ -40,7 +40,7 @@ final public class FocusLogDataAccessFeature: ConditionalFeature {
         public static var hideFromTimeline: Bool = true
         
         public static func perform(context: ActionContext<InputType>, presenter: PresenterType, completion: Completion) -> Completion.Status {
-            guard let logs = FocusFeature.dependencies.developmentFocusLogging else {
+            guard let logs = FocusFeature.dependencies.focusLoggingHistory else {
                 return completion.completedSync(.successWithFeatureTermination)
             }
 

--- a/FlintUI/iOS/View Controllers/TimelineViewController.swift
+++ b/FlintUI/iOS/View Controllers/TimelineViewController.swift
@@ -127,7 +127,7 @@ public class TimelineViewController: UITableViewController, TimelinePresenter {
     // MARK: Outlets and actions
     
     @objc public func shareAudit() {
-        let url = DebugReporting.gatherReportZip(options: [.machineReadableFormat])
+        let url = DebugReporting.gatherReportZip(options: [])
         let shareViewController = UIActivityViewController(activityItems: [url], applicationActivities: nil)
         shareViewController.completionWithItemsHandler = { _, _, _, _ in
             try? FileManager.default.removeItem(at: url)

--- a/FlintUISandbox/AppDelegate.swift
+++ b/FlintUISandbox/AppDelegate.swift
@@ -57,6 +57,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var controller: AuthorisationController?
     
     func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        ActionStacksFeature.isEnabled = true
+        
         let fileOutput = try! FileLoggerOutput(name: "uisandbox")
         Logging.setLoggerOutputs(development: [fileOutput], developmentLevel: .debug, production: nil, productionLevel: .off)
         
@@ -66,7 +68,11 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         }
     
         Flint.register(group: FlintUIFeatures.self)
-        
+
+        if let focus = FocusFeature.request(FocusFeature.focus) {
+            focus.perform(withInput: .init(feature: FakeFeature.self))
+        }
+
         // Spit out a fake action every few seconds
         let bgLogs = FakeFeature.logs(for: "BG Timer")
 


### PR DESCRIPTION
For now we'll combine prod + dev logs when collecting focus logs. The issue is we want to be able to have a live viewer that sees the updates coming in, with paging to go into past entries, and with two separate histories this is too ugly to other with given that we issue async notifications to the UI if there are live updates.

If you're focusing you probably want it all. One caveat: we can't currently tell which entries are from prod or from dev but we can tackle that after 1.0. We'll probably add an entry source to LogEvent so every log event is fully self describing.

Fixes #15