### PR TITLE
Fix typealias warnings by holding the generics right.

### DIFF
--- a/FlintCore/Actions/UIKit-Specific/DismissingUIAction.swift
+++ b/FlintCore/Actions/UIKit-Specific/DismissingUIAction.swift
@@ -30,9 +30,7 @@ import UIKit
 /// ```
 /// - see: `DismissUIInput`
 #if os(iOS) || os(tvOS)
-public protocol DismissingUIAction: UIAction {
-    typealias InputType = DismissUIInput
-    typealias PresenterType = UIViewController
+public protocol DismissingUIAction: UIAction where InputType == DismissUIInput, PresenterType == UIViewController {
 }
 
 extension DismissingUIAction {

--- a/FlintCore/Focus/FocusFeature.swift
+++ b/FlintCore/Focus/FocusFeature.swift
@@ -56,9 +56,6 @@ final public class FocusFeature: ConditionalFeature {
         
         /// Wire up the delegate to snoop on log entries
         if isAvailable == true {
-            var developmentLogging: FocusLogging?
-            var productionLogging: FocusLogging?
-
             let focusLoggingHistory = FocusLogging(maxCount: defaultMaxLogEvents)
             if let development = Logging.development {
                 development.add(output: focusLoggingHistory)

--- a/FlintCore/Siri Intents and Shortcuts/IntentAction.swift
+++ b/FlintCore/Siri Intents and Shortcuts/IntentAction.swift
@@ -30,12 +30,13 @@ public protocol IntentAction: IntentBackgroundAction {
     /// The type of the `INIntent` thatt this action will implement. This is the Xcode-generated response type produced from your
     /// intent definition configuration.
     associatedtype IntentType: FlintIntent
+
     /// The type of the `INIntentResponse` for the `INIntent`. This is the Xcode-generated response type produced from your
     /// intent definition configuration.
     associatedtype IntentResponseType: FlintIntentResponse
 
     /// Automatic aliasing of the presenter to the appropriate type for Intents
-    typealias PresenterType = IntentResponsePresenter<IntentResponseType>
+    associatedtype PresenterType = IntentResponsePresenter<IntentResponseType>
 
     /// Implement this function if the Action supports a Siri Intent for Shortcuts. This is used to register
     /// a shortcut intent with Siri if you have the `IntentShortcutDonationFeature` enabled.

--- a/FlintCore/Siri Intents and Shortcuts/IntentAction.swift
+++ b/FlintCore/Siri Intents and Shortcuts/IntentAction.swift
@@ -26,7 +26,7 @@ public protocol IntentBackgroundAction: Action {
 #if canImport(Intents) && os(iOS)
 /// Adopt this protocol when implementing an action that fulfills a Siri Intent via an Intent Extension
 @available(iOS 12, *)
-public protocol IntentAction: IntentBackgroundAction {
+public protocol IntentAction: IntentBackgroundAction where PresenterType == IntentResponsePresenter<IntentResponseType> {
     /// The type of the `INIntent` thatt this action will implement. This is the Xcode-generated response type produced from your
     /// intent definition configuration.
     associatedtype IntentType: FlintIntent
@@ -34,9 +34,6 @@ public protocol IntentAction: IntentBackgroundAction {
     /// The type of the `INIntentResponse` for the `INIntent`. This is the Xcode-generated response type produced from your
     /// intent definition configuration.
     associatedtype IntentResponseType: FlintIntentResponse
-
-    /// Automatic aliasing of the presenter to the appropriate type for Intents
-    associatedtype PresenterType = IntentResponsePresenter<IntentResponseType>
 
     /// Implement this function if the Action supports a Siri Intent for Shortcuts. This is used to register
     /// a shortcut intent with Siri if you have the `IntentShortcutDonationFeature` enabled.

--- a/FlintCore/Siri Intents and Shortcuts/UIKit-Specific/StaticActionBinding+Shortcut+Extensions.swift
+++ b/FlintCore/Siri Intents and Shortcuts/UIKit-Specific/StaticActionBinding+Shortcut+Extensions.swift
@@ -41,7 +41,7 @@ extension StaticActionBinding {
 }
 
 @available(iOS 12, *)
-extension StaticActionBinding where ActionType: IntentAction, ActionType.PresenterType == IntentResponsePresenter<ActionType.IntentResponseType> {
+extension StaticActionBinding where ActionType: IntentAction {
 
     /// Perform an intent intended for this action. The action will be passed the input extracted from the intent,
     /// and a presenter that automatically calls the completion handler passed as an argument.

--- a/FlintCore/Siri Intents and Shortcuts/UIKit-Specific/StaticActionBinding+Shortcut+Extensions.swift
+++ b/FlintCore/Siri Intents and Shortcuts/UIKit-Specific/StaticActionBinding+Shortcut+Extensions.swift
@@ -41,7 +41,7 @@ extension StaticActionBinding {
 }
 
 @available(iOS 12, *)
-extension StaticActionBinding where ActionType: IntentAction {
+extension StaticActionBinding where ActionType: IntentAction, ActionType.PresenterType == IntentResponsePresenter<ActionType.IntentResponseType> {
 
     /// Perform an intent intended for this action. The action will be passed the input extracted from the intent,
     /// and a presenter that automatically calls the completion handler passed as an argument.
@@ -53,7 +53,7 @@ extension StaticActionBinding where ActionType: IntentAction {
     /// - param completion: The intent handler completion closure from an Intent Extension handler.
     /// - return: The result of performing the action.
     public func perform(withIntent intent: ActionType.IntentType, completion: @escaping (ActionType.IntentResponseType) -> Void) throws -> MappedActionResult {
-        let presenter = IntentResponsePresenter(completion: completion)
+        let presenter = ActionType.PresenterType(completion: completion)
         return try perform(withIntent: intent, presenter: presenter)
     }
     

--- a/FlintCore/Siri Intents and Shortcuts/UIKit-Specific/VerifiedActionBinding+Shortcut+Extensions.swift
+++ b/FlintCore/Siri Intents and Shortcuts/UIKit-Specific/VerifiedActionBinding+Shortcut+Extensions.swift
@@ -42,7 +42,7 @@ extension VerifiedActionBinding {
 }
 
 @available(iOS 12, *)
-extension VerifiedActionBinding where ActionType: IntentAction {
+extension VerifiedActionBinding where ActionType: IntentAction, ActionType.PresenterType == IntentResponsePresenter<ActionType.IntentResponseType> {
 
     /// Perform an intent intended for this action. The action will be passed the input extracted from the intent,
     /// and a presenter that automatically calls the completion handler passed as an argument.
@@ -55,7 +55,7 @@ extension VerifiedActionBinding where ActionType: IntentAction {
     ///
     /// - return: The result of performing the action.
     public func perform(withIntent intent: ActionType.IntentType, completion: @escaping (ActionType.IntentResponseType) -> Void) throws -> MappedActionResult {
-        let presenter = IntentResponsePresenter(completion: completion)
+        let presenter = ActionType.PresenterType(completion: completion)
         return try perform(withIntent: intent, presenter: presenter)
     }
     
@@ -69,7 +69,7 @@ extension VerifiedActionBinding where ActionType: IntentAction {
     /// - param completion: The intent handler completion closure from an Intent Extension handler.
     ///
     /// - return: The result of performing the action.
-    public func perform(withIntent intent: ActionType.IntentType, presenter: ActionType.PresenterType) throws -> MappedActionResult {
+    public func perform(withIntent intent: ActionType.IntentType, presenter: IntentResponsePresenter<ActionType.IntentResponseType>) throws -> MappedActionResult {
         /// !!! TODO: We probably need a Result<T> here as nil could be valid
         guard let inputFromIntent = try ActionType.input(fromIntent: intent) else {
             flintUsageError("Failed to create input from intent \(intent)")

--- a/FlintCore/Siri Intents and Shortcuts/UIKit-Specific/VerifiedActionBinding+Shortcut+Extensions.swift
+++ b/FlintCore/Siri Intents and Shortcuts/UIKit-Specific/VerifiedActionBinding+Shortcut+Extensions.swift
@@ -42,7 +42,7 @@ extension VerifiedActionBinding {
 }
 
 @available(iOS 12, *)
-extension VerifiedActionBinding where ActionType: IntentAction, ActionType.PresenterType == IntentResponsePresenter<ActionType.IntentResponseType> {
+extension VerifiedActionBinding where ActionType: IntentAction {
 
     /// Perform an intent intended for this action. The action will be passed the input extracted from the intent,
     /// and a presenter that automatically calls the completion handler passed as an argument.
@@ -69,7 +69,7 @@ extension VerifiedActionBinding where ActionType: IntentAction, ActionType.Prese
     /// - param completion: The intent handler completion closure from an Intent Extension handler.
     ///
     /// - return: The result of performing the action.
-    public func perform(withIntent intent: ActionType.IntentType, presenter: IntentResponsePresenter<ActionType.IntentResponseType>) throws -> MappedActionResult {
+    public func perform(withIntent intent: ActionType.IntentType, presenter: ActionType.PresenterType) throws -> MappedActionResult {
         /// !!! TODO: We probably need a Result<T> here as nil could be valid
         guard let inputFromIntent = try ActionType.input(fromIntent: intent) else {
             flintUsageError("Failed to create input from intent \(intent)")


### PR DESCRIPTION
Amen for Swift Forums.