### PR TITLE
Edit/add voice shortcut completion optionality and collateral fixes

### DIFF
--- a/FlintCore/Actions/UIKit-Specific/DismissingUIAction.swift
+++ b/FlintCore/Actions/UIKit-Specific/DismissingUIAction.swift
@@ -35,8 +35,8 @@ public protocol DismissingUIAction: UIAction {
     associatedtype PresenterType = UIViewController
 }
 
-extension DismissingUIAction where InputType == DismissUIInput, PresenterType == UIViewController {
-    public static func perform(context: ActionContext<InputType>, presenter: PresenterType, completion: Completion) -> Completion.Status {
+public extension DismissingUIAction where InputType == DismissUIInput, PresenterType == UIViewController {
+    static func perform(context: ActionContext<DismissUIInput>, presenter: UIViewController, completion: Completion) -> Completion.Status {
         presenter.dismiss(animated: context.input.animated)
         return completion.completedSync(.successWithFeatureTermination)
     }

--- a/FlintCore/Conditional Features/ConditionalActionBinding.swift
+++ b/FlintCore/Conditional Features/ConditionalActionBinding.swift
@@ -44,7 +44,7 @@ import Foundation
 /// - note: This is a completely discrete type from `StaticActionBinding` so that you cannot call `perform`
 /// with a conditional action, you must first request the conditional action using this binding, and then
 /// call perform with the `VerifiedActionBinding` received from that.
-public struct ConditionalActionBinding<FeatureType: ConditionalFeature, ActionType: Action>: CustomDebugStringConvertible {
+public struct ConditionalActionBinding<FeatureType, ActionType>: CustomDebugStringConvertible where FeatureType: ConditionalFeature, ActionType: Action {
 
     public var debugDescription: String {
         return "ConditionalActionBinding action \(ActionType.self) of \(FeatureType.self)"

--- a/FlintCore/Conditional Features/ConditionalFeature.swift
+++ b/FlintCore/Conditional Features/ConditionalFeature.swift
@@ -44,7 +44,7 @@ public protocol ConditionalFeature: ConditionalFeatureDefinition {
     /// the action directly or on a specific `ActionSession` if the feature is available
     ///
     /// - note: This is defined in the protocol so you may override it if you have other ways to validate features.
-    static func request<T>(_ actionBinding: ConditionalActionBinding<Self, T>) -> VerifiedActionBinding<Self, T>?
+    static func request<ActionType>(_ actionBinding: ConditionalActionBinding<Self, ActionType>) -> VerifiedActionBinding<Self, ActionType>? where ActionType: Action
 }
 
 /// Convenience functions to do useful things with conditional features
@@ -54,7 +54,7 @@ public extension ConditionalFeature {
     /// If so, returns a request that can be used to perform the action, otherwise `nil`.
     ///
     /// The default `isAvailable` implementation will delegate to the `AvailabilityChecker` to see if the feature is available.
-    static func request<ActionType>(_ actionBinding: ConditionalActionBinding<Self, ActionType>) -> VerifiedActionBinding<Self, ActionType>? {
+    static func request<ActionType>(_ actionBinding: ConditionalActionBinding<Self, ActionType>) -> VerifiedActionBinding<Self, ActionType>? where ActionType: Action {
         // Sanity checks and footgun avoidance
         Flint.requiresSetup()
         Flint.requiresPrepared(feature: Self.self)

--- a/FlintCore/Siri Intents and Shortcuts/UIKit-Specific/StaticActionBinding+Shortcut+Extensions.swift
+++ b/FlintCore/Siri Intents and Shortcuts/UIKit-Specific/StaticActionBinding+Shortcut+Extensions.swift
@@ -31,7 +31,7 @@ extension StaticActionBinding {
     @available(iOS 12, *)
     public func addVoiceShortcut(forInput input: ActionType.InputType,
                                  presenter: UIViewController,
-                                 completion: @escaping (_ result: AddVoiceShortcutResult) -> Void) throws {
+                                 completion: ((_ result: AddVoiceShortcutResult) -> Void)? = nil) throws {
         try VoiceShortcuts.addVoiceShortcut(forAction: ActionType.self,
                                             feature: FeatureType.self,
                                             input: input,
@@ -115,7 +115,7 @@ public extension StaticActionBinding where ActionType: IntentAction, ActionType.
     @available(iOS 12, *)
     func addVoiceShortcut(withInput input: ActionType.InputType,
                                  presenter: UIViewController,
-                                 completion: @escaping (_ result: AddVoiceShortcutResult) -> Void) throws {
+                                 completion: ((_ result: AddVoiceShortcutResult) -> Void)? = nil) throws {
         try VoiceShortcuts.addVoiceShortcut(forAction: ActionType.self,
                                             feature: FeatureType.self,
                                             input: input,
@@ -137,7 +137,7 @@ public extension StaticActionBinding where ActionType: IntentAction, ActionType.
     @available(iOS 12, *)
     func editVoiceShortcut(_ shortcut: INVoiceShortcut,
                                   presenter: UIViewController,
-                                  completion: @escaping (_ result: EditVoiceShortcutResult) -> Void) {
+                                  completion: ((_ result: EditVoiceShortcutResult) -> Void)? = nil) {
         VoiceShortcuts.editVoiceShortcut(shortcut,
                                          presenter: presenter,
                                          completion: completion)

--- a/FlintCore/Siri Intents and Shortcuts/UIKit-Specific/VerifiedActionBinding+Shortcut+Extensions.swift
+++ b/FlintCore/Siri Intents and Shortcuts/UIKit-Specific/VerifiedActionBinding+Shortcut+Extensions.swift
@@ -32,7 +32,7 @@ extension VerifiedActionBinding {
     @available(iOS 12, *)
     public func addVoiceShortcut(forInput input: ActionType.InputType,
                                  presenter: UIViewController,
-                                 completion: @escaping (_ result: AddVoiceShortcutResult) -> Void) throws {
+                                 completion: ((_ result: AddVoiceShortcutResult) -> Void)? = nil) throws {
         try VoiceShortcuts.addVoiceShortcut(forAction: ActionType.self,
                                             feature: FeatureType.self,
                                             input: input,
@@ -119,7 +119,7 @@ public extension VerifiedActionBinding where ActionType: IntentAction, ActionTyp
     @available(iOS 12, *)
     func addVoiceShortcut(forInput input: ActionType.InputType,
                                  presenter: UIViewController,
-                                 completion: @escaping (_ result: AddVoiceShortcutResult) -> Void) throws {
+                                 completion: ((_ result: AddVoiceShortcutResult) -> Void)? = nil) throws {
         try VoiceShortcuts.addVoiceShortcut(forAction: ActionType.self,
                                             feature: FeatureType.self,
                                             input: input,
@@ -141,7 +141,7 @@ public extension VerifiedActionBinding where ActionType: IntentAction, ActionTyp
     @available(iOS 12, *)
     func editVoiceShortcut(_ shortcut: INVoiceShortcut,
                                   presenter: UIViewController,
-                                  completion: @escaping (_ result: EditVoiceShortcutResult) -> Void) {
+                                  completion: ((_ result: EditVoiceShortcutResult) -> Void)? = nil) {
         VoiceShortcuts.editVoiceShortcut(shortcut,
                                          presenter: presenter,
                                          completion: completion)

--- a/FlintCore/Siri Intents and Shortcuts/UIKit-Specific/VoiceShortcuts.swift
+++ b/FlintCore/Siri Intents and Shortcuts/UIKit-Specific/VoiceShortcuts.swift
@@ -50,7 +50,7 @@ class VoiceShortcuts {
                                                           feature: FeatureType.Type,
                                                           input: ActionType.InputType,
                                                           presenter: UIViewController,
-                                                          completion: @escaping (_ result: AddVoiceShortcutResult) -> Void) throws where ActionType: Action, FeatureType: FeatureDefinition {
+                                                          completion: ((_ result: AddVoiceShortcutResult) -> Void)?) throws where ActionType: Action, FeatureType: FeatureDefinition {
         guard let activity = try ActionActivityMappings.createActivity(for: action, of: feature, with: input, appLink: nil) else {
             flintUsageError("The action \(action) on feature \(feature) did not return an activity for the input \(input)")
         }
@@ -73,7 +73,7 @@ class VoiceShortcuts {
                                                           feature: FeatureType.Type,
                                                           input: ActionType.InputType,
                                                           presenter: UIViewController,
-                                                          completion: @escaping (_ result: AddVoiceShortcutResult) -> Void) throws where ActionType: IntentAction, FeatureType: FeatureDefinition {
+                                                          completion: ((_ result: AddVoiceShortcutResult) -> Void)?) throws where ActionType: IntentAction, FeatureType: FeatureDefinition {
         let shortcut: INShortcut
         if let intent = try ActionType.intent(forInput: input) {
             guard let intentShortcut = INShortcut(intent: intent) else {
@@ -112,7 +112,7 @@ class VoiceShortcuts {
     var addVoiceShortcutViewController: INUIAddVoiceShortcutViewController?
     var completion: ((_ result: AddVoiceShortcutResult) -> Void)?
     
-    func show(for shortcut: INShortcut, presenter: UIViewController, completion: @escaping (_ result: AddVoiceShortcutResult) -> Void) {
+    func show(for shortcut: INShortcut, presenter: UIViewController, completion: ((_ result: AddVoiceShortcutResult) -> Void)?) {
         let addVoiceShortcutViewController = INUIAddVoiceShortcutViewController(shortcut: shortcut)
         addVoiceShortcutViewController.delegate = self
         self.completion = completion
@@ -160,7 +160,7 @@ class VoiceShortcuts {
     var editVoiceShortcutViewController: INUIEditVoiceShortcutViewController?
     var completion: ((_ result: EditVoiceShortcutResult) -> Void)?
     
-    func show(for voiceShortcut: INVoiceShortcut, presenter: UIViewController, completion: @escaping (_ result: EditVoiceShortcutResult) -> Void) {
+    func show(for voiceShortcut: INVoiceShortcut, presenter: UIViewController, completion: ((_ result: EditVoiceShortcutResult) -> Void)?) {
         let editVoiceShortcutViewController = INUIEditVoiceShortcutViewController(voiceShortcut: voiceShortcut)
         editVoiceShortcutViewController.delegate = self
         self.completion = completion

--- a/FlintCore/Siri Intents and Shortcuts/UIKit-Specific/VoiceShortcuts.swift
+++ b/FlintCore/Siri Intents and Shortcuts/UIKit-Specific/VoiceShortcuts.swift
@@ -99,7 +99,7 @@ class VoiceShortcuts {
     @available(iOS 12, *)
     static func editVoiceShortcut(_ voiceShortcut: INVoiceShortcut,
                                   presenter: UIViewController,
-                                  completion: @escaping (_ result: EditVoiceShortcutResult) -> Void) {
+                                  completion: ((_ result: EditVoiceShortcutResult) -> Void)?) {
         EditVoiceShortcutCoordinator.shared.show(for: voiceShortcut, presenter: presenter, completion: completion)
     }
 }

--- a/FlintUI/iOS/View Controllers/FeatureBrowserViewController.swift
+++ b/FlintUI/iOS/View Controllers/FeatureBrowserViewController.swift
@@ -33,7 +33,7 @@ public class FeatureBrowserViewController: UITableViewController {
     // MARK: - Data
     
     func prepareData() {
-        rootFeatures = Flint.allFeatures.flatMap {
+        rootFeatures = Flint.allFeatures.compactMap {
             if let _ = $0.feature as? FeatureGroup.Type,
                     $0.feature.parent == nil {
                 return $0.feature

--- a/FlintUI/iOS/View Controllers/PurchaseBrowserViewController.swift
+++ b/FlintUI/iOS/View Controllers/PurchaseBrowserViewController.swift
@@ -191,7 +191,8 @@ public class PurchaseBrowserViewController: UITableViewController {
     
     @objc public func dismissPurchases() {
         if let request = PurchaseBrowserFeature.hide.request() {
-            request.perform(withInput: .animated(true), presenter: self)
+            let r: VerifiedActionBinding<PurchaseBrowserFeature, HidePurchaseBrowserAction> = request
+            r.perform(withInput: .animated(true), presenter: self)
         }
     }
     


### PR DESCRIPTION
Makes completion optional on editVoiceShortcut/addVoiceShortcut

Also: It transpired the new warning-avoiding handling of defaulting the Input/Presenter types on DissmissingUIAction did not correctly bind the action on conditional features. The `request` generic function on conditional features was incorrectly specified so the type of the action would get  lost, so the input would default to NoInput (from Action's default)