### PR TITLE
More compile issues with UIKitForMac builds

### DIFF
--- a/FlintCore.xcodeproj/xcshareddata/xcschemes/FlintCore-iOS.xcscheme
+++ b/FlintCore.xcodeproj/xcshareddata/xcschemes/FlintCore-iOS.xcscheme
@@ -34,30 +34,25 @@
                ReferencedContainer = "container:FlintCore.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "490BE4662124616C00B6AC91"
-               BuildableName = "FlintCore-iOS-UITests.xctest"
-               BlueprintName = "FlintCore-iOS-UITests"
-               ReferencedContainer = "container:FlintCore.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
       </BuildActionEntries>
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES"
       enableUBSanitizer = "YES"
       codeCoverageEnabled = "YES"
-      onlyGenerateCoverageForSpecifiedTargets = "YES"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      onlyGenerateCoverageForSpecifiedTargets = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "49CCF0A91F8BB1B200F7020E"
+            BuildableName = "FlintCore.framework"
+            BlueprintName = "FlintCore-iOS"
+            ReferencedContainer = "container:FlintCore.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
       <CodeCoverageTargets>
          <BuildableReference
             BuildableIdentifier = "primary"
@@ -79,17 +74,6 @@
             </BuildableReference>
          </TestableReference>
       </Testables>
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "49CCF0A91F8BB1B200F7020E"
-            BuildableName = "FlintCore.framework"
-            BlueprintName = "FlintCore-iOS"
-            ReferencedContainer = "container:FlintCore.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       buildConfiguration = "Debug"
@@ -100,7 +84,6 @@
       useCustomWorkingDirectory = "NO"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
-      stopOnEveryThreadSanitizerIssue = "YES"
       debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
@@ -112,8 +95,6 @@
             ReferencedContainer = "container:FlintCore.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
-      <AdditionalOptions>
-      </AdditionalOptions>
    </LaunchAction>
    <ProfileAction
       buildConfiguration = "Release"

--- a/FlintCore/Siri Intents and Shortcuts/IntentShortcutDonationFeature.swift
+++ b/FlintCore/Siri Intents and Shortcuts/IntentShortcutDonationFeature.swift
@@ -25,19 +25,19 @@ public final class IntentShortcutDonationFeature: ConditionalFeature {
     }
     
     /// Set this to `false` to disable automatic intent donation
-#if os(iOS) || os(watchOS)
+#if canImport(Intents) && ((os(iOS) && !targetEnvironment(UIKitForMac)) || os(watchOS))
     public static var isEnabled: Bool? = true
 #else
     public static var isEnabled: Bool? = false
 #endif
 
-#if canImport(Network) && os(iOS)
+#if canImport(Network) && os(iOS) && !targetEnvironment(UIKitForMac)
     @available(iOS 12, *)
     static var donateShortcut = action(DonateShortcutIntentAction.self)
 #endif
 
     public static func prepare(actions: FeatureActionsBuilder) {
-#if canImport(Network) && os(iOS)
+#if canImport(Network) && os(iOS) && !targetEnvironment(UIKitForMac)
         if #available(iOS 12, *) {
             actions.declare(donateShortcut)
 

--- a/FlintCore/Siri Intents and Shortcuts/Intents-Specific/DonateShortcutIntentAction.swift
+++ b/FlintCore/Siri Intents and Shortcuts/Intents-Specific/DonateShortcutIntentAction.swift
@@ -7,10 +7,11 @@
 //
 
 import Foundation
-#if canImport(Intents)
+#if canImport(Intents) && !targetEnvironment(UIKitForMac)
 import Intents
 #endif
 
+#if canImport(Intents) && !targetEnvironment(UIKitForMac)
 /// Action that donates the given input (a wrapped INIntent) as a possible shortcut.
 ///
 /// Called from tthe action dispatch observer for actions that indicate ethey should be donated.
@@ -36,3 +37,4 @@ final class DonateShortcutIntentAction: UIAction {
         }
     }
 }
+#endif

--- a/FlintCore/Siri Intents and Shortcuts/Intents-Specific/SiriShortcutDonatingActionDispatchObserver.swift
+++ b/FlintCore/Siri Intents and Shortcuts/Intents-Specific/SiriShortcutDonatingActionDispatchObserver.swift
@@ -10,7 +10,7 @@ import Foundation
 
 /// This observes all action dispatch and detects actions performed that match
 /// shortcut donation conventions and donates them.
-#if canImport(Network) && os(iOS)
+#if canImport(Network) && os(iOS) && !targetEnvironment(UIKitForMac)
 @available(iOS 12, *) 
 class SiriShortcutDonatingActionDispatchObserver: ActionDispatchObserver {
     let loggers: ContextualLoggers


### PR DESCRIPTION
Hopefully this will fix:
```
/Carthage/Checkouts/Flint/FlintCore/Siri Intents and Shortcuts/IntentShortcutDonationFeature.swift:36:40: error: use of unresolved identifier 'DonateShortcutIntentAction'
    static var donateShortcut = action(DonateShortcutIntentAction.self)
                                       ^~~~~~~~~~~~~~~~~~~~~~~~~~
/Carthage/Checkouts/Flint/FlintCore/Siri Intents and Shortcuts/IntentShortcutDonationFeature.swift:46:61: error: use of unresolved identifier 'SiriShortcutDonatingActionDispatchObserver'
                ActionSession.main.dispatcher.add(observer: SiriShortcutDonatingActionDispatchObserver())
                                                            ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```