### PR TITLE
Reinstate the PresenterType declaration, it is still required it seems

### DIFF
--- a/FlintCore/Siri Intents and Shortcuts/IntentAction.swift
+++ b/FlintCore/Siri Intents and Shortcuts/IntentAction.swift
@@ -43,8 +43,8 @@ public protocol IntentAction: IntentBackgroundAction where PresenterType == Inte
     /// intent definition configuration.
     associatedtype IntentResponseType: FlintIntentResponse
 
-//    /// Set the default presenter type, so our convenient extensions are available
-//    associatedtype PresenterType = IntentResponsePresenter<IntentResponseType>
+    /// Set the default presenter type, so our convenient extensions are available
+    associatedtype PresenterType = IntentResponsePresenter<IntentResponseType>
     
     /// Implement this function if the Action supports a Siri Intent for Shortcuts. This is used to register
     /// a shortcut intent with Siri if you have the `IntentShortcutDonationFeature` enabled.


### PR DESCRIPTION
Without this, any actions that conform to IntentAction fail to compile as the compiler doesn't see the `PresenterType` which should be inferred by the compiler from the `where` clause in `IntentAction` as per Slava's comments in WWDC labs.